### PR TITLE
TFP-1971 unngår å sette passiv samme entitet som builder bruker

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
@@ -65,9 +65,12 @@ public class LagreVedtakTask implements ProsessTaskHandler {
             // TODO: Gjør generisk
             //VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) mottattVedtak);
 
-            Optional<VedtakYtelseEntitet> siste = extractor.hentSisteVedtatteFor((YtelseV1) mottattVedtak);
+            Optional<VedtakYtelseEntitet> siste = extractor.hentAktivtVedtakFor((YtelseV1)mottattVedtak);
+            if (siste.isEmpty()) {
+                siste = extractor.hentSisteVedtatteFor((YtelseV1) mottattVedtak);
+            }
             VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) mottattVedtak);
-
+            
             ytelseRepository.lagre(builder, siste);
         }
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.abakus.vedtak;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -13,6 +14,7 @@ import javax.validation.ValidatorFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
+import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseEntitet;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
 import no.nav.foreldrepenger.abakus.vedtak.extract.v1.ExtractFromYtelseV1;
 import no.nav.foreldrepenger.abakus.vedtak.json.JacksonJsonConfig;
@@ -61,9 +63,12 @@ public class LagreVedtakTask implements ProsessTaskHandler {
         }
         if (mottattVedtak != null) {
             // TODO: Gjør generisk
+            //VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) mottattVedtak);
+
+            Optional<VedtakYtelseEntitet> siste = extractor.hentSisteVedtatteFor((YtelseV1) mottattVedtak);
             VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) mottattVedtak);
 
-            ytelseRepository.lagre(builder);
+            ytelseRepository.lagre(builder, siste);
         }
     }
 }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTask.java
@@ -70,7 +70,7 @@ public class LagreVedtakTask implements ProsessTaskHandler {
                 siste = extractor.hentSisteVedtatteFor((YtelseV1) mottattVedtak);
             }
             VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) mottattVedtak);
-            
+
             ytelseRepository.lagre(builder, siste);
         }
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseRepository.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseRepository.java
@@ -89,7 +89,7 @@ public class VedtakYtelseRepository {
         entityManager.flush();
     }
 
-    private Optional<VedtakYtelseEntitet> hentYtelseFor(AktørId aktørId, Saksnummer saksnummer, Fagsystem fagsystem, YtelseType ytelseType) {
+    public Optional<VedtakYtelseEntitet> hentYtelseFor(AktørId aktørId, Saksnummer saksnummer, Fagsystem fagsystem, YtelseType ytelseType) {
         Objects.requireNonNull(aktørId, "aktørId");
         Objects.requireNonNull(saksnummer, "saksnummer");
         Objects.requireNonNull(fagsystem, "fagsystem");

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/ExtractFromYtelse.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/ExtractFromYtelse.java
@@ -1,8 +1,12 @@
 package no.nav.foreldrepenger.abakus.vedtak.extract;
 
+import java.util.Optional;
+
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
+import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseEntitet;
 import no.nav.vedtak.ytelse.Ytelse;
 
 public interface ExtractFromYtelse<T extends Ytelse> {
     VedtakYtelseBuilder extractFrom(T ytelse);
+    Optional<VedtakYtelseEntitet> hentSisteVedtatteFor(T ytelse);
 }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/ExtractFromYtelse.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/ExtractFromYtelse.java
@@ -9,4 +9,5 @@ import no.nav.vedtak.ytelse.Ytelse;
 public interface ExtractFromYtelse<T extends Ytelse> {
     VedtakYtelseBuilder extractFrom(T ytelse);
     Optional<VedtakYtelseEntitet> hentSisteVedtatteFor(T ytelse);
+    Optional<VedtakYtelseEntitet> hentAktivtVedtakFor(T ytelse);
 }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
@@ -76,6 +76,16 @@ public class ExtractFromYtelseV1 implements ExtractFromYtelse<YtelseV1> {
         return repository.hentSisteYtelseFor(aktørId, saksnummer, fagsystem, ytelseType);
     }
 
+    @Override
+    public Optional<VedtakYtelseEntitet> hentAktivtVedtakFor(YtelseV1 ytelse) {
+        Fagsystem fagsystem = getFagsystem(ytelse.getFagsystem());
+        no.nav.foreldrepenger.abakus.kodeverk.YtelseType ytelseType = getYtelseType(ytelse.getType());
+        Saksnummer saksnummer = new Saksnummer(ytelse.getSaksnummer());
+        AktørId aktørId = new AktørId(ytelse.getAktør().getVerdi());
+
+        return repository.hentYtelseFor(aktørId, saksnummer, fagsystem, ytelseType);
+    }
+
     private YtelseStatus getStatus(no.nav.vedtak.ytelse.v1.YtelseStatus kodeverk) {
         return (YtelseStatus) kodeverkRepository.finn(kodeverkTilKodeliste.get(kodeverk.getKodeverk()), kodeverk.getKode());
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/tjeneste/YtelseRestTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/tjeneste/YtelseRestTjeneste.java
@@ -58,7 +58,10 @@ public class YtelseRestTjeneste {
 
         //VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) request);
 
-        Optional<VedtakYtelseEntitet> siste = extractor.hentSisteVedtatteFor((YtelseV1) request);
+        Optional<VedtakYtelseEntitet> siste = extractor.hentAktivtVedtakFor((YtelseV1)request);
+        if (siste.isEmpty()) {
+            siste = extractor.hentSisteVedtatteFor((YtelseV1) request);
+        }
         VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) request);
 
         ytelseRepository.lagre(builder, siste);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/tjeneste/YtelseRestTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/tjeneste/YtelseRestTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.abakus.vedtak.tjeneste;
 import static no.nav.vedtak.sikkerhet.abac.BeskyttetRessursActionAttributt.CREATE;
 import static no.nav.vedtak.sikkerhet.abac.BeskyttetRessursResourceAttributt.FAGSAK;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -18,6 +19,7 @@ import javax.ws.rs.core.Response;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
+import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseEntitet;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
 import no.nav.foreldrepenger.abakus.vedtak.extract.v1.ExtractFromYtelseV1;
 import no.nav.vedtak.felles.jpa.Transaction;
@@ -54,9 +56,12 @@ public class YtelseRestTjeneste {
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
     public Response arbeidsforholdForReferanse(@NotNull @TilpassetAbacAttributt(supplierClass = AbacDataSupplier.class) @Valid Ytelse request) {
 
+        //VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) request);
+
+        Optional<VedtakYtelseEntitet> siste = extractor.hentSisteVedtatteFor((YtelseV1) request);
         VedtakYtelseBuilder builder = extractor.extractFrom((YtelseV1) request);
 
-        ytelseRepository.lagre(builder);
+        ytelseRepository.lagre(builder, siste);
 
         return Response.accepted().build();
     }


### PR DESCRIPTION
Avventer diskusjon om framgangsmåte før jeg gjør noe med hentYtelserForIPeriode 

Her har builder-fella slått til: forrige entitet og nybygd er samme entitet som settes aktiv = false.
Dessuten vil erOppdatering() være TRUE for ny()