### PR TITLE
TFP-1201 versjon som er feilsoft i q, failhard i p+lokal

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -102,14 +102,15 @@ public class InnhentingSamletTjeneste {
         return aktørConsumer.hentPersonIdentForAktørId(aktørId.getId()).map(PersonIdent::new).orElseThrow();
     }
 
-    public boolean brukInfotrygdRest() {
-        return !Cluster.DEV_FSS.equals(Environment.current().getCluster());
-        //return true;
-        //return unleash != null && unleash.isEnabled(REST_GJELDER, false);
+    private boolean envUnstable() {
+        return Cluster.DEV_FSS.equals(Environment.current().getCluster());
     }
 
     public List<InfotrygdYtelseGrunnlag> innhentInfotrygdGrunnlag(AktørId aktørId, Interval periode) {
         var ident = getFnrFraAktørId(aktørId);
+        if (envUnstable()) {
+            return innhentingInfotrygdTjeneste.getInfotrygdYtelserFailSoft(ident, periode);
+        }
         return innhentingInfotrygdTjeneste.getInfotrygdYtelser(ident, periode);
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -61,10 +61,9 @@ public class YtelseRegisterInnhenting {
             return;
         }
 
-        if (innhentingSamletTjeneste.brukInfotrygdRest()) {
-            List<InfotrygdYtelseGrunnlag> alleGrunnlag = innhentingSamletTjeneste.innhentInfotrygdGrunnlag(aktørId, opplysningsPeriode);
-            alleGrunnlag.forEach(grunnlag -> oversettInfotrygdYtelseGrunnlagTilYtelse(aktørYtelseBuilder, grunnlag));
-        } else {
+        List<InfotrygdYtelseGrunnlag> alleGrunnlag = innhentingSamletTjeneste.innhentInfotrygdGrunnlag(aktørId, opplysningsPeriode);
+        alleGrunnlag.forEach(grunnlag -> oversettInfotrygdYtelseGrunnlagTilYtelse(aktørYtelseBuilder, grunnlag));
+        /* TODO (JOL): Delete etter validering i P/Q
             List<InfotrygdSakOgGrunnlag> sammenstilt = innhentingSamletTjeneste.getSammenstiltSakOgGrunnlag(aktørId, opplysningsPeriode, medGrunnlag);
             for (InfotrygdSakOgGrunnlag ytelse : sammenstilt) {
                 LOGGER.info("Sammenstilt sak : {}", ytelse);
@@ -74,7 +73,7 @@ public class YtelseRegisterInnhenting {
                 }
             }
         }
-
+        */
         List<MeldekortUtbetalingsgrunnlagSak> arena = innhentingSamletTjeneste.hentYtelserTjenester(aktørId, opplysningsPeriode);
         aktørYtelseBuilder.tilbakestillYtelserFraKildeBeholdAvsluttede(Fagsystem.ARENA);
         for (MeldekortUtbetalingsgrunnlagSak sak : arena) {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/InnhentingInfotrygdTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/InnhentingInfotrygdTjeneste.java
@@ -79,6 +79,16 @@ public class InnhentingInfotrygdTjeneste {
     public List<InfotrygdYtelseGrunnlag> getInfotrygdYtelser(PersonIdent ident, Interval periode) {
         List<Grunnlag> rest = grunnlag.hentAggregertGrunnlag(ident.getIdent(), dato(periode.getStart()), dato(periode.getEnd()));
 
+        return mapTilInfotrygdYtelseGrunnlag(rest);
+    }
+
+    public List<InfotrygdYtelseGrunnlag> getInfotrygdYtelserFailSoft(PersonIdent ident, Interval periode) {
+        List<Grunnlag> rest = grunnlag.hentAggregertGrunnlagFailSoft(ident.getIdent(), dato(periode.getStart()), dato(periode.getEnd()));
+
+        return mapTilInfotrygdYtelseGrunnlag(rest);
+    }
+
+    private List<InfotrygdYtelseGrunnlag> mapTilInfotrygdYtelseGrunnlag(List<Grunnlag> rest) {
         var mappedGrunnlag = rest.stream()
             .filter(g -> !YtelseType.UDEFINERT.equals(TemaReverse.reverseMap(g.getTema().getKode().name(), LOG)))
             .map(this::restTilInfotrygdYtelseGrunnlag)

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/rest/beregningsgrunnlag/InfotrygdGrunnlag.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/rest/beregningsgrunnlag/InfotrygdGrunnlag.java
@@ -7,8 +7,8 @@ import no.nav.vedtak.felles.integrasjon.infotrygd.grunnlag.v1.respons.Grunnlag;
 
 public interface InfotrygdGrunnlag {
 
-    List<Grunnlag> hentGrunnlag(String fnr, LocalDate fom);
-
     List<Grunnlag> hentGrunnlag(String fnr, LocalDate fom, LocalDate tom);
+
+    List<Grunnlag> hentGrunnlagFailSoft(String fnr, LocalDate fom, LocalDate tom);
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/rest/beregningsgrunnlag/felles/InfotrygdGrunnlagAggregator.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/rest/beregningsgrunnlag/felles/InfotrygdGrunnlagAggregator.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.abakus.registerdata.ytelse.infotrygd.rest.beregningsgrunnlag.felles;
 
-import static java.time.LocalDate.now;
 import static java.util.stream.Collectors.toList;
 
 import java.time.LocalDate;
@@ -27,16 +26,18 @@ public class InfotrygdGrunnlagAggregator {
         this.tjenester = tjenester.stream().collect(toList());
     }
 
-    public List<Grunnlag> hentAggregertGrunnlag(String fnr, LocalDate fom) {
-        return hentAggregertGrunnlag(fnr, fom, now());
-    }
-
-
     public List<Grunnlag> hentAggregertGrunnlag(String fnr, LocalDate fom, LocalDate tom) {
         return tjenester.stream()
                 .map(t -> t.hentGrunnlag(fnr, fom, tom))
                 .flatMap(List::stream)
                 .collect(toList());
+    }
+
+    public List<Grunnlag> hentAggregertGrunnlagFailSoft(String fnr, LocalDate fom, LocalDate tom) {
+        return tjenester.stream()
+            .map(t -> t.hentGrunnlagFailSoft(fnr, fom, tom))
+            .flatMap(List::stream)
+            .collect(toList());
     }
 
 

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterinnhentingTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterinnhentingTest.java
@@ -60,7 +60,6 @@ public class YtelseRegisterinnhentingTest {
         k.setOpplysningsperiode(DatoIntervallEntitet.fraOgMed(LocalDate.now().minusMonths(17)));
         when(samletTjeneste.getSammenstiltSakOgGrunnlag(any(), any(), anyBoolean())).thenReturn(Collections.emptyList());
         when(samletTjeneste.hentYtelserTjenester(any(), any())).thenReturn(Collections.emptyList());
-        when(samletTjeneste.brukInfotrygdRest()).thenReturn(Boolean.TRUE);
         when(samletTjeneste.innhentInfotrygdGrunnlag(any(), any())).thenReturn(Collections.emptyList());
         when(vedtakYtelseRepository.hentYtelserForIPeriode(any(), any(), any())).thenReturn(List.of(vy));
         InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());


### PR DESCRIPTION
Rest-tjenestene til Infotrygd har kjørt stabilt i P lenge. Er stabile mot VTP.
De vil ikke virke i T4 og det noe noen gremlins i Qn.
Denne versjonen er failsoft i Qn og Tn - så vi kan få prodsatt.
