### PR TITLE
Fjerner bruk av DatoIntervallEntitet fra felles-db

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtale.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtale.java
@@ -22,9 +22,9 @@ import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.DiffIgnore;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.AntallTimer;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.konfig.Tid;
 
 @Table(name = "IAY_AKTIVITETS_AVTALE")
@@ -65,7 +65,7 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ChangeTracked
     @Column(name = "siste_loennsendringsdato")
@@ -80,7 +80,7 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
      * filtrering av modellen)
      */
     @Transient
-    private DatoIntervallEntitet overstyrtPeriode;
+    private IntervallEntitet overstyrtPeriode;
 
     AktivitetsAvtale() {
         // hibernate
@@ -96,7 +96,7 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
         this.periode = aktivitetsAvtale.getPeriodeUtenOverstyring();
     }
 
-    public AktivitetsAvtale(AktivitetsAvtale avtale, DatoIntervallEntitet overstyrtPeriode) {
+    public AktivitetsAvtale(AktivitetsAvtale avtale, IntervallEntitet overstyrtPeriode) {
         this(avtale);
         this.overstyrtPeriode = overstyrtPeriode;
     }
@@ -156,11 +156,11 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
      *
      * @return hele perioden
      */
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return erOverstyrtPeriode() ? overstyrtPeriode : periode;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 
@@ -173,7 +173,7 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
      *
      * @return Hele den originale perioden, uten overstyringer.
      */
-    public DatoIntervallEntitet getPeriodeUtenOverstyring() {
+    public IntervallEntitet getPeriodeUtenOverstyring() {
         return periode;
     }
 
@@ -198,7 +198,7 @@ public class AktivitetsAvtale extends BaseEntitet implements IndexKey {
         return sisteLønnsendringsdato;
     }
 
-    public boolean matcherPeriode(DatoIntervallEntitet aktivitetsAvtale) {
+    public boolean matcherPeriode(IntervallEntitet aktivitetsAvtale) {
         return getPeriode().equals(aktivitetsAvtale);
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtaleBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtaleBuilder.java
@@ -4,8 +4,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class AktivitetsAvtaleBuilder {
     private final AktivitetsAvtale aktivitetsAvtaleEntitet;
@@ -34,7 +34,7 @@ public class AktivitetsAvtaleBuilder {
         return this;
     }
 
-    public AktivitetsAvtaleBuilder medPeriode(DatoIntervallEntitet periode) {
+    public AktivitetsAvtaleBuilder medPeriode(IntervallEntitet periode) {
         this.aktivitetsAvtaleEntitet.setPeriode(periode);
         return this;
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktørYtelseEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktørYtelseEntitet.java
@@ -26,12 +26,12 @@ import javax.persistence.Version;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.vedtak.domene.TemaUnderkategori;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Table(name = "IAY_AKTOER_YTELSE")
 @Entity(name = "AktørYtelse")
@@ -107,7 +107,7 @@ public class AktørYtelseEntitet extends BaseEntitet implements AktørYtelse, In
         return YtelseBuilder.oppdatere(ytelse).medYtelseType(type).medKilde(fagsystem).medSaksnummer(saksnummer);
     }
 
-    YtelseBuilder getYtelseBuilderForType(Fagsystem fagsystem, YtelseType type, Saksnummer saksnummer, DatoIntervallEntitet periode, Optional<LocalDate> tidligsteAnvistFom) {
+    YtelseBuilder getYtelseBuilderForType(Fagsystem fagsystem, YtelseType type, Saksnummer saksnummer, IntervallEntitet periode, Optional<LocalDate> tidligsteAnvistFom) {
         // OBS kan være flere med samme Saksnummer+FOM: Konvensjon ifm satsjustering
         List<Ytelse> aktuelleYtelser = getAlleYtelser().stream()
             .filter(ya -> ya.getKilde().equals(fagsystem) && ya.getRelatertYtelseType().equals(type) && (saksnummer.equals(ya.getSaksnummer())
@@ -130,7 +130,7 @@ public class AktørYtelseEntitet extends BaseEntitet implements AktørYtelse, In
         return YtelseBuilder.oppdatere(ytelse).medYtelseType(type).medKilde(fagsystem).medSaksnummer(saksnummer);
     }
 
-    YtelseBuilder getYtelseBuilderForType(Fagsystem fagsystem, YtelseType type, TemaUnderkategori typeKategori, DatoIntervallEntitet periode) {
+    YtelseBuilder getYtelseBuilderForType(Fagsystem fagsystem, YtelseType type, TemaUnderkategori typeKategori, IntervallEntitet periode) {
         Optional<Ytelse> ytelse = getAlleYtelser().stream()
             .filter(ya -> ya.getKilde().equals(fagsystem) && ya.getRelatertYtelseType().equals(type)
                 && ya.getBehandlingsTema().equals(typeKategori) && (periode.getFomDato().equals(ya.getPeriode().getFomDato())))

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/BekreftetPermisjon.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/BekreftetPermisjon.java
@@ -15,7 +15,7 @@ import org.hibernate.annotations.JoinColumnOrFormula;
 import org.hibernate.annotations.JoinFormula;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.BekreftetPermisjonStatus;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 @Embeddable
 public class BekreftetPermisjon {
@@ -30,13 +30,13 @@ public class BekreftetPermisjon {
         @AttributeOverride(name = "fomDato", column = @Column(name = "bekreftet_permisjon_fom")),
         @AttributeOverride(name = "tomDato", column = @Column(name = "bekreftet_permisjon_tom"))
     })
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     public BekreftetPermisjon() {
     }
 
     public BekreftetPermisjon(LocalDate permisjonFom, LocalDate permisjonTom, BekreftetPermisjonStatus status) {
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(permisjonFom, permisjonTom);
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(permisjonFom, permisjonTom);
         this.status = status;
     }
 
@@ -49,7 +49,7 @@ public class BekreftetPermisjon {
         return status;
     }
 
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektArbeidYtelseAggregatBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektArbeidYtelseAggregatBuilder.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdReferanse;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektsKilde;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
@@ -20,7 +21,7 @@ import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.vedtak.domene.TemaUnderkategori;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -358,12 +359,12 @@ public class InntektArbeidYtelseAggregatBuilder {
             return kladd.getYtelseBuilderForType(fagsystem, type, sakId);
         }
 
-        public YtelseBuilder getYtelselseBuilderForType(Fagsystem fagsystem, YtelseType type, Saksnummer sakId, DatoIntervallEntitet periode,
+        public YtelseBuilder getYtelselseBuilderForType(Fagsystem fagsystem, YtelseType type, Saksnummer sakId, IntervallEntitet periode,
                                                         Optional<LocalDate> tidligsteAnvistFom) {
             return kladd.getYtelseBuilderForType(fagsystem, type, sakId, periode, tidligsteAnvistFom);
         }
 
-        public YtelseBuilder getYtelselseBuilderForType(Fagsystem fagsystem, YtelseType type, TemaUnderkategori typeKategori, DatoIntervallEntitet periode) {
+        public YtelseBuilder getYtelselseBuilderForType(Fagsystem fagsystem, YtelseType type, TemaUnderkategori typeKategori, IntervallEntitet periode) {
             return kladd.getYtelseBuilderForType(fagsystem, type, typeKategori, periode);
         }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektFilter.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektFilter.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektsKilde;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 /**
  * Filter for å hente inntekter og inntektsposter fra grunnlag. Tilbyr håndtering av skjæringstidspunkt og filtereing på inntektskilder slik
@@ -209,7 +209,7 @@ public class InntektFilter {
             return false;
         }
         if (skjæringstidspunkt != null) {
-            DatoIntervallEntitet periode = inntektspost.getPeriode();
+            IntervallEntitet periode = inntektspost.getPeriode();
             if (venstreSideASkjæringstidspunkt) {
                 return periode.getFomDato().isBefore(skjæringstidspunkt.plusDays(1));
             } else {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/Inntektspost.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/Inntektspost.java
@@ -2,8 +2,8 @@ package no.nav.foreldrepenger.abakus.domene.iay;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.SkatteOgAvgiftsregelType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface Inntektspost {
 
@@ -38,7 +38,9 @@ public interface Inntektspost {
 
     YtelseInntektspostType getYtelseType();
     
-    /** Periode inntektsposten gjelder. */
-    DatoIntervallEntitet getPeriode();
+    /** Periode inntektsposten gjelder.
+     * @return
+     */
+    IntervallEntitet getPeriode();
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektspostEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/InntektspostEntitet.java
@@ -25,8 +25,8 @@ import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.SkatteOgAvgiftsregelType
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "Inntektspost")
 @Table(name = "IAY_INNTEKTSPOST")
@@ -64,7 +64,7 @@ public class InntektspostEntitet extends BaseEntitet implements Inntektspost, In
     private YtelseInntektspostType ytelse = OffentligYtelseType.UDEFINERT;
 
     @Embedded
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "verdi", column = @Column(name = "beloep", nullable = false)))
@@ -115,7 +115,7 @@ public class InntektspostEntitet extends BaseEntitet implements Inntektspost, In
     }
 
     public void setPeriode(LocalDate fom, LocalDate tom) {
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
     }
 
     @Override
@@ -124,7 +124,7 @@ public class InntektspostEntitet extends BaseEntitet implements Inntektspost, In
     }
     
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
     

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/OpptjeningInntektPeriode.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/OpptjeningInntektPeriode.java
@@ -4,11 +4,11 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 public class OpptjeningInntektPeriode {
 
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
     private BigDecimal beløp;
     private Opptjeningsnøkkel opptjeningsnøkkel;
     private InntektspostType type;

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/PermisjonEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/PermisjonEntitet.java
@@ -23,8 +23,8 @@ import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.PermisjonsbeskrivelseTyp
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "Permisjon")
 @Table(name = "IAY_PERMISJON")
@@ -44,7 +44,7 @@ public class PermisjonEntitet extends BaseEntitet implements Permisjon, IndexKey
     private PermisjonsbeskrivelseType permisjonsbeskrivelseType;
 
     @Embedded
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ChangeTracked
     @Embedded
@@ -64,7 +64,7 @@ public class PermisjonEntitet extends BaseEntitet implements Permisjon, IndexKey
      */
     PermisjonEntitet(Permisjon permisjon) {
         this.permisjonsbeskrivelseType = permisjon.getPermisjonsbeskrivelseType();
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(permisjon.getFraOgMed(), permisjon.getTilOgMed());
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(permisjon.getFraOgMed(), permisjon.getTilOgMed());
         this.prosentsats = permisjon.getProsentsats();
     }
 
@@ -84,9 +84,9 @@ public class PermisjonEntitet extends BaseEntitet implements Permisjon, IndexKey
 
     public void setPeriode(LocalDate fraOgMed, LocalDate tilOgMed) {
         if (tilOgMed != null) {
-            this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(fraOgMed, tilOgMed);
+            this.periode = IntervallEntitet.fraOgMedTilOgMed(fraOgMed, tilOgMed);
         } else {
-            this.periode = DatoIntervallEntitet.fraOgMed(fraOgMed);
+            this.periode = IntervallEntitet.fraOgMed(fraOgMed);
         }
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetBuilder.java
@@ -3,8 +3,8 @@ package no.nav.foreldrepenger.abakus.domene.iay;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class YrkesaktivitetBuilder {
     private final YrkesaktivitetEntitet kladd;
@@ -104,7 +104,7 @@ public class YrkesaktivitetBuilder {
         return kladd;
     }
 
-    public AktivitetsAvtaleBuilder getAktivitetsAvtaleBuilder(DatoIntervallEntitet aktivitetsPeriode, boolean erAnsettelsesperioden) {
+    public AktivitetsAvtaleBuilder getAktivitetsAvtaleBuilder(IntervallEntitet aktivitetsPeriode, boolean erAnsettelsesperioden) {
         AktivitetsAvtaleBuilder oppdater = AktivitetsAvtaleBuilder.oppdater(kladd.getAlleAktivitetsAvtaler()
             .stream()
             .filter(aa -> aa.matcherPeriode(aktivitetsPeriode)
@@ -114,7 +114,7 @@ public class YrkesaktivitetBuilder {
         return oppdater;
     }
 
-    public void fjernPeriode(DatoIntervallEntitet aktivitetsPeriode) {
+    public void fjernPeriode(IntervallEntitet aktivitetsPeriode) {
         kladd.fjernPeriode(aktivitetsPeriode);
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetEntitet.java
@@ -27,8 +27,8 @@ import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "Yrkesaktivitet")
 @Table(name = "IAY_YRKESAKTIVITET")
@@ -218,7 +218,7 @@ public class YrkesaktivitetEntitet extends BaseEntitet implements Yrkesaktivitet
             '}';
     }
 
-    void fjernPeriode(DatoIntervallEntitet aktivitetsPeriode) {
+    void fjernPeriode(IntervallEntitet aktivitetsPeriode) {
         aktivitetsAvtale.removeIf(aa -> aa.matcherPeriode(aktivitetsPeriode));
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetFilter.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YrkesaktivitetFilter.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdInfo
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdOverstyring;
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdOverstyrtePerioderEntitet;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 /**
  * Brukt til å filtrere registrerte yrkesaktiviteter, overstyrte arbeidsforhold og frilans arbeidsforhold etter skjæringstidspunkt.
@@ -243,7 +243,7 @@ public class YrkesaktivitetFilter {
             Set<AktivitetsAvtale> avtaler = new LinkedHashSet<>();
             overstyrtePerioder.forEach(overstyrtPeriode -> yaAvtaler.stream()
                 .filter(AktivitetsAvtale::erAnsettelsesPeriode)
-                .filter(aa -> DatoIntervallEntitet.TIDENES_ENDE.equals(aa.getPeriodeUtenOverstyring().getTomDato()))
+                .filter(aa -> IntervallEntitet.TIDENES_ENDE.equals(aa.getPeriodeUtenOverstyring().getTomDato()))
                 .filter(aa -> overstyrtPeriode.getOverstyrtePeriode().getFomDato().isEqual(aa.getPeriodeUtenOverstyring().getFomDato()))
                 .forEach(avtale -> avtaler.add(new AktivitetsAvtale(avtale, overstyrtPeriode.getOverstyrtePeriode()))));
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/Ytelse.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/Ytelse.java
@@ -3,12 +3,12 @@ package no.nav.foreldrepenger.abakus.domene.iay;
 import java.util.Collection;
 import java.util.Optional;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.vedtak.domene.TemaUnderkategori;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface Ytelse {
 
@@ -18,7 +18,7 @@ public interface Ytelse {
 
     YtelseStatus getStatus();
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     Saksnummer getSaksnummer();
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistBuilder.java
@@ -2,9 +2,9 @@ package no.nav.foreldrepenger.abakus.domene.iay;
 
 import java.math.BigDecimal;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class YtelseAnvistBuilder {
     private final YtelseAnvistEntitet ytelseAnvistEntitet;
@@ -31,7 +31,7 @@ public class YtelseAnvistBuilder {
         return this;
     }
 
-    public YtelseAnvistBuilder medAnvistPeriode(DatoIntervallEntitet intervallEntitet) {
+    public YtelseAnvistBuilder medAnvistPeriode(IntervallEntitet intervallEntitet) {
         this.ytelseAnvistEntitet.setAnvistPeriode(intervallEntitet);
         return this;
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistEntitet.java
@@ -20,9 +20,9 @@ import javax.persistence.Version;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "YtelseAnvistEntitet")
 @Table(name = "IAY_YTELSE_ANVIST")
@@ -38,7 +38,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet anvistPeriode;
+    private IntervallEntitet anvistPeriode;
 
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "verdi", column = @Column(name = "beloep")))
@@ -64,7 +64,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
     }
 
     public YtelseAnvistEntitet(YtelseAnvist ytelseAnvist) {
-        this.anvistPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(ytelseAnvist.getAnvistFOM(), ytelseAnvist.getAnvistTOM());
+        this.anvistPeriode = IntervallEntitet.fraOgMedTilOgMed(ytelseAnvist.getAnvistFOM(), ytelseAnvist.getAnvistTOM());
         this.beløp = ytelseAnvist.getBeløp().orElse(null);
         this.dagsats = ytelseAnvist.getDagsats().orElse(null);
         this.utbetalingsgradProsent = ytelseAnvist.getUtbetalingsgradProsent().orElse(null);
@@ -108,7 +108,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
         this.dagsats = dagsats;
     }
 
-    void setAnvistPeriode(DatoIntervallEntitet periode) {
+    void setAnvistPeriode(IntervallEntitet periode) {
         this.anvistPeriode = periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseBuilder.java
@@ -2,12 +2,12 @@ package no.nav.foreldrepenger.abakus.domene.iay;
 
 import java.util.Optional;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.vedtak.domene.TemaUnderkategori;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class YtelseBuilder {
 
@@ -41,7 +41,7 @@ public class YtelseBuilder {
         return this;
     }
 
-    public YtelseBuilder medPeriode(DatoIntervallEntitet intervallEntitet) {
+    public YtelseBuilder medPeriode(IntervallEntitet intervallEntitet) {
         ytelseEntitet.setPeriode(intervallEntitet);
         return this;
     }
@@ -71,7 +71,7 @@ public class YtelseBuilder {
         return this;
     }
 
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return ytelseEntitet.getPeriode();
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseEntitet.java
@@ -27,12 +27,12 @@ import javax.persistence.Version;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.vedtak.domene.TemaUnderkategori;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "YtelseEntitet")
 @Table(name = "IAY_RELATERT_YTELSE")
@@ -51,7 +51,7 @@ public class YtelseEntitet extends BaseEntitet implements Ytelse, IndexKey {
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ChangeTracked
     @Convert(converter = YtelseStatus.KodeverdiConverter.class)
@@ -147,11 +147,11 @@ public class YtelseEntitet extends BaseEntitet implements Ytelse, IndexKey {
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseFilter.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseFilter.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 /**
  * Filter for å hente ytelser fra grunnlag. Tilbyr håndtering av skjæringstidspunkt og filtereing på ytelser slik
@@ -92,7 +92,7 @@ public class YtelseFilter {
 
     private boolean skalMedEtterSkjæringstidspunktVurdering(Ytelse ytelse) {
         if (skjæringstidspunkt != null) {
-            DatoIntervallEntitet periode = ytelse.getPeriode();
+            IntervallEntitet periode = ytelse.getPeriode();
             if (venstreSideASkjæringstidspunkt) {
                 return periode.getFomDato().isBefore(skjæringstidspunkt.plusDays(1));
             } else {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyring.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyring.java
@@ -33,9 +33,9 @@ import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.BekreftetPermisjonStatus
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 /**
  * Overstyring av arbeidsforhold angitt av saksbehandler.
@@ -166,7 +166,7 @@ public class ArbeidsforholdOverstyring extends BaseEntitet implements IndexKey {
 
     public void leggTilOverstyrtPeriode(LocalDate fom, LocalDate tom) {
         ArbeidsforholdOverstyrtePerioderEntitet overstyrtPeriode = new ArbeidsforholdOverstyrtePerioderEntitet();
-        overstyrtPeriode.setPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom));
+        overstyrtPeriode.setPeriode(IntervallEntitet.fraOgMedTilOgMed(fom, tom));
         overstyrtPeriode.setArbeidsforholdOverstyring(this);
         arbeidsforholdOverstyrtePerioder.add(overstyrtPeriode);
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyrtePerioder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyrtePerioder.java
@@ -1,9 +1,9 @@
 package no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold;
 
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 public interface ArbeidsforholdOverstyrtePerioder {
 
-    DatoIntervallEntitet getOverstyrtePeriode();
+    IntervallEntitet getOverstyrtePeriode();
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyrtePerioderEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdOverstyrtePerioderEntitet.java
@@ -18,7 +18,7 @@ import javax.persistence.Version;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 @Table(name = "IAY_OVERSTYRTE_PERIODER")
 @Entity(name = "ArbeidsforholdOverstyrtePerioder")
@@ -33,7 +33,7 @@ public class ArbeidsforholdOverstyrtePerioderEntitet extends BaseEntitet impleme
         @AttributeOverride(name = "fomDato", column = @Column(name = "FOM")),
         @AttributeOverride(name = "tomDato", column = @Column(name = "TOM"))
     })
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @JsonBackReference
     @ManyToOne(optional = false)
@@ -52,7 +52,7 @@ public class ArbeidsforholdOverstyrtePerioderEntitet extends BaseEntitet impleme
         this.periode = arbeidsforholdOverstyrtePerioderEntitet.getOverstyrtePeriode();
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 
@@ -82,7 +82,7 @@ public class ArbeidsforholdOverstyrtePerioderEntitet extends BaseEntitet impleme
     }
 
     @Override
-    public DatoIntervallEntitet getOverstyrtePeriode() {
+    public IntervallEntitet getOverstyrtePeriode() {
         return periode;
     }
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/Gradering.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/Gradering.java
@@ -1,7 +1,7 @@
 package no.nav.foreldrepenger.abakus.domene.iay.inntektsmelding;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface Gradering {
     /**
@@ -9,7 +9,7 @@ public interface Gradering {
      *
      * @return perioden
      */
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     /**
      * En arbeidstaker kan kombinere foreldrepenger med deltidsarbeid.

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/GraderingEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/GraderingEntitet.java
@@ -20,8 +20,8 @@ import javax.persistence.Version;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "Gradering")
 @Table(name = "IAY_GRADERING")
@@ -37,7 +37,7 @@ public class GraderingEntitet extends BaseEntitet implements Gradering, IndexKey
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "verdi", column = @Column(name = "arbeidstid_prosent", updatable = false, nullable = false)))
@@ -51,13 +51,13 @@ public class GraderingEntitet extends BaseEntitet implements Gradering, IndexKey
     GraderingEntitet() {
     }
 
-    private GraderingEntitet(DatoIntervallEntitet periode, Stillingsprosent arbeidstidProsent) {
+    private GraderingEntitet(IntervallEntitet periode, Stillingsprosent arbeidstidProsent) {
         this.arbeidstidProsent = arbeidstidProsent;
         this.periode = periode;
     }
 
     public GraderingEntitet(LocalDate fom, LocalDate tom, BigDecimal arbeidstidProsent) {
-        this(tom == null ? DatoIntervallEntitet.fraOgMed(fom) : DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom), new Stillingsprosent(arbeidstidProsent));
+        this(tom == null ? IntervallEntitet.fraOgMed(fom) : IntervallEntitet.fraOgMedTilOgMed(fom, tom), new Stillingsprosent(arbeidstidProsent));
     }
 
     GraderingEntitet(Gradering gradering) {
@@ -74,7 +74,7 @@ public class GraderingEntitet extends BaseEntitet implements Gradering, IndexKey
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/NaturalYtelse.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/NaturalYtelse.java
@@ -1,11 +1,11 @@
 package no.nav.foreldrepenger.abakus.domene.iay.inntektsmelding;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface NaturalYtelse {
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     Beløp getBeloepPerMnd();
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/NaturalYtelseEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/NaturalYtelseEntitet.java
@@ -24,8 +24,8 @@ import org.hibernate.annotations.JoinFormula;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "NaturalYtelse")
 @Table(name = "IAY_NATURAL_YTELSE")
@@ -41,7 +41,7 @@ public class NaturalYtelseEntitet extends BaseEntitet implements NaturalYtelse, 
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "verdi", column = @Column(name = "beloep_mnd", nullable = false)))
@@ -65,7 +65,7 @@ public class NaturalYtelseEntitet extends BaseEntitet implements NaturalYtelse, 
     public NaturalYtelseEntitet(LocalDate fom, LocalDate tom, BigDecimal beloepPerMnd, NaturalYtelseType type) {
         this.beloepPerMnd = new Beløp(beloepPerMnd);
         this.type = type;
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
     }
 
     NaturalYtelseEntitet(NaturalYtelse naturalYtelse) {
@@ -74,7 +74,7 @@ public class NaturalYtelseEntitet extends BaseEntitet implements NaturalYtelse, 
         this.type = naturalYtelse.getType();
     }
 
-    public NaturalYtelseEntitet(DatoIntervallEntitet datoIntervall, BigDecimal beløpPerMnd, NaturalYtelseType naturalYtelseType) {
+    public NaturalYtelseEntitet(IntervallEntitet datoIntervall, BigDecimal beløpPerMnd, NaturalYtelseType naturalYtelseType) {
         this(datoIntervall.getFomDato(), datoIntervall.getTomDato(), beløpPerMnd, naturalYtelseType);
     }
 
@@ -88,7 +88,7 @@ public class NaturalYtelseEntitet extends BaseEntitet implements NaturalYtelse, 
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/UtsettelsePeriode.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/UtsettelsePeriode.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.abakus.domene.iay.inntektsmelding;
 
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 public interface UtsettelsePeriode {
     /**
@@ -8,7 +8,7 @@ public interface UtsettelsePeriode {
      *
      * @return perioden
      */
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     /**
      * Årsaken til utsettelsen

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/UtsettelsePeriodeEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/UtsettelsePeriodeEntitet.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.JoinFormula;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 @Entity(name = "UtsettelsePeriode")
 @Table(name = "IAY_UTSETTELSE_PERIODE")
@@ -37,7 +37,7 @@ public class UtsettelsePeriodeEntitet extends BaseEntitet implements UtsettelseP
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ManyToOne
     @JoinColumnsOrFormulas(value = {
@@ -52,13 +52,13 @@ public class UtsettelsePeriodeEntitet extends BaseEntitet implements UtsettelseP
     private long versjon;
 
     private UtsettelsePeriodeEntitet(LocalDate fom, LocalDate tom) {
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
         this.årsak = UtsettelseÅrsak.FERIE;
     }
 
     private UtsettelsePeriodeEntitet(LocalDate fom, LocalDate tom, UtsettelseÅrsak årsak) {
         this.årsak = årsak;
-        this.periode = DatoIntervallEntitet.fraOgMedTilOgMed(fom, tom);
+        this.periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
     }
 
     UtsettelsePeriodeEntitet() {
@@ -83,7 +83,7 @@ public class UtsettelsePeriodeEntitet extends BaseEntitet implements UtsettelseP
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittAnnenAktivitetEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittAnnenAktivitetEntitet.java
@@ -20,7 +20,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittAnnenAkti
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 
 @Table(name = "IAY_ANNEN_AKTIVITET")
@@ -33,7 +33,7 @@ public class OppgittAnnenAktivitetEntitet extends BaseEntitet implements Oppgitt
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "oppgitt_opptjening_id", nullable = false, updatable = false)
@@ -46,7 +46,7 @@ public class OppgittAnnenAktivitetEntitet extends BaseEntitet implements Oppgitt
     @ChangeTracked
     private ArbeidType arbeidType;
 
-    public OppgittAnnenAktivitetEntitet(DatoIntervallEntitet periode, ArbeidType arbeidType) {
+    public OppgittAnnenAktivitetEntitet(IntervallEntitet periode, ArbeidType arbeidType) {
         this.periode = periode;
         this.arbeidType = arbeidType;
     }
@@ -66,7 +66,7 @@ public class OppgittAnnenAktivitetEntitet extends BaseEntitet implements Oppgitt
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittArbeidsforholdEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittArbeidsforholdEntitet.java
@@ -22,9 +22,9 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittArbeidsfo
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
 import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 /**
  * Entitetsklasse for oppgitte arbeidsforhold.
@@ -49,7 +49,7 @@ public class OppgittArbeidsforholdEntitet extends BaseEntitet implements Oppgitt
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @Convert(converter = BooleanToStringConverter.class)
     @Column(name = "utenlandsk_inntekt", nullable = false)
@@ -88,11 +88,11 @@ public class OppgittArbeidsforholdEntitet extends BaseEntitet implements Oppgitt
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittEgenNæringEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittEgenNæringEntitet.java
@@ -23,10 +23,10 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.kodeverk.VirksomhetType;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
 import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 
 @Table(name = "IAY_EGEN_NAERING")
@@ -43,7 +43,7 @@ public class OppgittEgenNæringEntitet extends BaseEntitet implements OppgittEge
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ChangeTracked
     @Embedded
@@ -112,11 +112,11 @@ public class OppgittEgenNæringEntitet extends BaseEntitet implements OppgittEge
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittFrilansoppdragEntitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittFrilansoppdragEntitet.java
@@ -15,7 +15,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittFrilansop
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 
 @Table(name = "IAY_OPPGITT_FRILANSOPPDRAG")
@@ -35,13 +35,13 @@ public class OppgittFrilansoppdragEntitet extends BaseEntitet implements Oppgitt
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
 
     OppgittFrilansoppdragEntitet() {
     }
 
-    public OppgittFrilansoppdragEntitet(String oppdragsgiver, DatoIntervallEntitet periode) {
+    public OppgittFrilansoppdragEntitet(String oppdragsgiver, IntervallEntitet periode) {
         this.oppdragsgiver = oppdragsgiver;
         this.periode = periode;
     }
@@ -55,7 +55,7 @@ public class OppgittFrilansoppdragEntitet extends BaseEntitet implements Oppgitt
         this.frilans = frilans;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 
@@ -85,7 +85,7 @@ public class OppgittFrilansoppdragEntitet extends BaseEntitet implements Oppgitt
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittOpptjeningBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/OppgittOpptjeningBuilder.java
@@ -15,9 +15,9 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittEgenNæri
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittFrilans;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittOpptjening;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.kodeverk.VirksomhetType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class OppgittOpptjeningBuilder {
 
@@ -91,7 +91,7 @@ public class OppgittOpptjeningBuilder {
             return new EgenNæringBuilder(new OppgittEgenNæringEntitet());
         }
 
-        public EgenNæringBuilder medPeriode(DatoIntervallEntitet periode) {
+        public EgenNæringBuilder medPeriode(IntervallEntitet periode) {
             this.entitet.setPeriode(periode);
             return this;
         }
@@ -179,7 +179,7 @@ public class OppgittOpptjeningBuilder {
             return new OppgittArbeidsforholdBuilder(new OppgittArbeidsforholdEntitet());
         }
 
-        public OppgittArbeidsforholdBuilder medPeriode(DatoIntervallEntitet periode) {
+        public OppgittArbeidsforholdBuilder medPeriode(IntervallEntitet periode) {
             this.entitet.setPeriode(periode);
             return this;
         }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittAnnenAktivitet.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittAnnenAktivitet.java
@@ -1,11 +1,11 @@
 package no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 public interface OppgittAnnenAktivitet {
 
     ArbeidType getArbeidType();
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittArbeidsforhold.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittArbeidsforhold.java
@@ -3,8 +3,8 @@ package no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag;
 import java.time.LocalDate;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface OppgittArbeidsforhold {
 
@@ -12,7 +12,7 @@ public interface OppgittArbeidsforhold {
 
     LocalDate getTilOgMed();
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     Boolean erUtenlandskInntekt();
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittEgenNæring.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittEgenNæring.java
@@ -4,9 +4,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.kodeverk.VirksomhetType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface OppgittEgenNæring {
 
@@ -14,7 +14,7 @@ public interface OppgittEgenNæring {
 
     LocalDate getTilOgMed();
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     VirksomhetType getVirksomhetType();
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittFrilansoppdrag.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/søknad/grunnlag/OppgittFrilansoppdrag.java
@@ -1,10 +1,10 @@
 package no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag;
 
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 public interface OppgittFrilansoppdrag {
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     String getOppdragsgiver();
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
@@ -51,6 +51,7 @@ import no.nav.abakus.iaygrunnlag.v1.InntektArbeidYtelseGrunnlagSakSnapshotDto;
 import no.nav.foreldrepenger.abakus.domene.iay.GrunnlagReferanse;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlagBuilder;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.IAYFraDtoMapper;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.IAYTilDtoMapper;
@@ -62,7 +63,6 @@ import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.Transaction;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
@@ -91,7 +91,7 @@ public class GrunnlagRestTjeneste {
         this.kodeverkRepository = kodeverkRepository;
     }
 
-    private static Periode mapPeriode(DatoIntervallEntitet datoIntervall) {
+    private static Periode mapPeriode(IntervallEntitet datoIntervall) {
         if (datoIntervall == null) {
             return new Periode(LocalDate.now(), LocalDate.now());
         }
@@ -264,11 +264,11 @@ public class GrunnlagRestTjeneste {
         }
         Periode opplysningsperiode = dto.getOpplysningsperiode();
         if (opplysningsperiode != null) {
-            kobling.setOpplysningsperiode(DatoIntervallEntitet.fraOgMedTilOgMed(opplysningsperiode.getFom(), opplysningsperiode.getTom()));
+            kobling.setOpplysningsperiode(IntervallEntitet.fraOgMedTilOgMed(opplysningsperiode.getFom(), opplysningsperiode.getTom()));
         }
         Periode opptjeningsperiode = dto.getOpptjeningsperiode();
         if (opptjeningsperiode != null) {
-            kobling.setOpptjeningsperiode(DatoIntervallEntitet.fraOgMedTilOgMed(opptjeningsperiode.getFom(), opptjeningsperiode.getTom()));
+            kobling.setOpptjeningsperiode(IntervallEntitet.fraOgMedTilOgMed(opptjeningsperiode.getFom(), opptjeningsperiode.getTom()));
         }
         // Diff & log endringer
         koblingTjeneste.lagre(kobling);

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapAktørArbeid.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapAktørArbeid.java
@@ -30,10 +30,10 @@ import no.nav.foreldrepenger.abakus.domene.iay.PermisjonBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.Yrkesaktivitet;
 import no.nav.foreldrepenger.abakus.domene.iay.YrkesaktivitetBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdInformasjon;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class MapAktørArbeid {
 
@@ -118,8 +118,8 @@ public class MapAktørArbeid {
                 .medSisteLønnsendringsdato(dto.getSistLønnsendring());
         }
 
-        private DatoIntervallEntitet mapPeriode(Periode periode) {
-            return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
+        private IntervallEntitet mapPeriode(Periode periode) {
+            return IntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
         }
 
         private InternArbeidsforholdRef mapArbeidsforholdRef(@SuppressWarnings("unused") Arbeidsgiver arbeidsgiver, ArbeidsforholdRefDto arbeidsforholdId) {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapAktørYtelse.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapAktørYtelse.java
@@ -29,12 +29,12 @@ import no.nav.foreldrepenger.abakus.domene.iay.YtelseGrunnlag;
 import no.nav.foreldrepenger.abakus.domene.iay.YtelseGrunnlagBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.YtelseStørrelse;
 import no.nav.foreldrepenger.abakus.domene.iay.YtelseStørrelseBuilder;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class MapAktørYtelse {
     private static final Comparator<YtelseDto> COMP_YTELSE = Comparator
@@ -80,8 +80,8 @@ public class MapAktørYtelse {
             return new AktørId(person.getIdent());
         }
 
-        private DatoIntervallEntitet mapPeriode(Periode periode) {
-            return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
+        private IntervallEntitet mapPeriode(Periode periode) {
+            return IntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
         }
 
         private YtelseBuilder mapYtelse(YtelseDto ytelseDto) {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapArbeidsforholdInformasjon.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapArbeidsforholdInformasjon.java
@@ -1,6 +1,15 @@
 package no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay;
 
-import no.nav.abakus.iaygrunnlag.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import no.nav.abakus.iaygrunnlag.Aktør;
+import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
+import no.nav.abakus.iaygrunnlag.ArbeidsforholdRefDto;
+import no.nav.abakus.iaygrunnlag.Organisasjon;
+import no.nav.abakus.iaygrunnlag.Periode;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdInformasjon;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdOverstyringDto;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdReferanseDto;
@@ -12,14 +21,13 @@ import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdOver
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdOverstyrtePerioderEntitet;
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdReferanse;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.BekreftetPermisjonStatus;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.KodeverkRepository;
-import no.nav.foreldrepenger.abakus.typer.*;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import no.nav.foreldrepenger.abakus.typer.AktørId;
+import no.nav.foreldrepenger.abakus.typer.EksternArbeidsforholdRef;
+import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
+import no.nav.foreldrepenger.abakus.typer.OrgNummer;
+import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
 
 class MapArbeidsforholdInformasjon {
 
@@ -161,7 +169,7 @@ class MapArbeidsforholdInformasjon {
             return new no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.BekreftetPermisjon(periode, bekreftetPermisjonStatus);
         }
 
-        private Periode mapPeriode(DatoIntervallEntitet periode) {
+        private Periode mapPeriode(IntervallEntitet periode) {
             return new Periode(periode.getFomDato(), periode.getTomDato());
         }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapOppgittOpptjening.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapOppgittOpptjening.java
@@ -31,11 +31,11 @@ import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittEgenNæri
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittFrilans;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittFrilansoppdrag;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.grunnlag.OppgittOpptjening;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.kodeverk.KodeverkRepository;
 import no.nav.foreldrepenger.abakus.kodeverk.Landkoder;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class MapOppgittOpptjening {
 
@@ -119,7 +119,7 @@ public class MapOppgittOpptjening {
             if (arbeidsforhold == null)
                 return null;
 
-            DatoIntervallEntitet periode1 = arbeidsforhold.getPeriode();
+            IntervallEntitet periode1 = arbeidsforhold.getPeriode();
             var periode = new Periode(periode1.getFomDato(), periode1.getTomDato());
             var arbeidType = KodeverkMapper.mapArbeidTypeTilDto(arbeidsforhold.getArbeidType());
 
@@ -143,7 +143,7 @@ public class MapOppgittOpptjening {
             if (egenNæring == null)
                 return null;
 
-            DatoIntervallEntitet periode1 = egenNæring.getPeriode();
+            IntervallEntitet periode1 = egenNæring.getPeriode();
             var periode = new Periode(periode1.getFomDato(), periode1.getTomDato());
 
             var org = egenNæring.getOrgnummer() == null ? null : new Organisasjon(egenNæring.getOrgnummer().getId());
@@ -246,7 +246,7 @@ public class MapOppgittOpptjening {
 
             var frilansoppdrag = mapEach(dto.getFrilansoppdrag(),
                 f -> new OppgittFrilansoppdragEntitet(f.getOppdragsgiver(),
-                    DatoIntervallEntitet.fraOgMedTilOgMed(f.getPeriode().getFom(), f.getPeriode().getTom())));
+                    IntervallEntitet.fraOgMedTilOgMed(f.getPeriode().getFom(), f.getPeriode().getTom())));
             frilans.setFrilansoppdrag(frilansoppdrag);
             return frilans;
         }
@@ -271,7 +271,7 @@ public class MapOppgittOpptjening {
                 .medNyoppstartet(dto.isNyoppstartet())
                 .medNærRelasjon(dto.isNærRelasjon())
                 .medVarigEndring(dto.isVarigEndring())
-                .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom()));
+                .medPeriode(IntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom()));
 
             Landkoder landkode = mapLandkoder(dto.getLandkode());
             builder.medUtenlandskVirksomhet(landkode, dto.getVirksomhetNavn());
@@ -287,7 +287,7 @@ public class MapOppgittOpptjening {
             var builder = OppgittArbeidsforholdBuilder.ny()
                 .medArbeidType(KodeverkMapper.mapArbeidType(dto.getArbeidTypeDto()))
                 .medErUtenlandskInntekt(dto.isErUtenlandskInntekt())
-                .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(dto1.getFom(), dto1.getTom()));
+                .medPeriode(IntervallEntitet.fraOgMedTilOgMed(dto1.getFom(), dto1.getTom()));
 
             Landkoder landkode = mapLandkoder(dto.getLandkode());
             builder.medUtenlandskVirksomhet(landkode, dto.getVirksomhetNavn());
@@ -300,7 +300,7 @@ public class MapOppgittOpptjening {
                 return null;
 
             Periode dto1 = dto.getPeriode();
-            var periode = DatoIntervallEntitet.fraOgMedTilOgMed(dto1.getFom(), dto1.getTom());
+            var periode = IntervallEntitet.fraOgMedTilOgMed(dto1.getFom(), dto1.getTom());
             var arbeidType = KodeverkMapper.mapArbeidType(dto.getArbeidTypeDto());
             return new OppgittAnnenAktivitetEntitet(periode, arbeidType);
         }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ByggYrkesaktiviteterTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ByggYrkesaktiviteterTjeneste.java
@@ -18,12 +18,12 @@ import no.nav.foreldrepenger.abakus.domene.iay.PermisjonBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.YrkesaktivitetBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.PermisjonsbeskrivelseType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.KodeverkRepository;
 import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.Arbeidsavtale;
 import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.Arbeidsforhold;
 import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.ArbeidsforholdIdentifikator;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 class ByggYrkesaktiviteterTjeneste {
 
@@ -74,7 +74,7 @@ class ByggYrkesaktiviteterTjeneste {
             .getAktivitetsAvtaleBuilder()
             .medProsentsats(arbeidsavtale.getStillingsprosent())
             .medSisteLønnsendringsdato(arbeidsavtale.getSisteLønnsendringsdato() != null ? arbeidsavtale.getSisteLønnsendringsdato() : fom)
-            .medPeriode(DatoIntervallEntitet.fraOgMed(fom));
+            .medPeriode(IntervallEntitet.fraOgMed(fom));
     }
 
     private Optional<Arbeidsavtale> finnSisteArbeidsavtale(List<Arbeidsforhold> arbeidsforhold) {
@@ -94,7 +94,7 @@ class ByggYrkesaktiviteterTjeneste {
     private AktivitetsAvtaleBuilder byggAnsettelsesPeriode(YrkesaktivitetBuilder builder, LocalDate fom) {
         return builder
             .getAktivitetsAvtaleBuilder()
-            .medPeriode(DatoIntervallEntitet.fraOgMed(fom));
+            .medPeriode(IntervallEntitet.fraOgMed(fom));
     }
 
     private void byggPermisjoner(YrkesaktivitetBuilder builder, Arbeidsforhold arbeidsforhold1) {
@@ -142,11 +142,11 @@ class ByggYrkesaktiviteterTjeneste {
 
     private AktivitetsAvtaleBuilder opprettAktivitetsAvtaler(Arbeidsavtale arbeidsavtale,
                                                              YrkesaktivitetBuilder yrkesaktivitetBuilder) {
-        DatoIntervallEntitet periode;
+        IntervallEntitet periode;
         if (arbeidsavtale.getArbeidsavtaleTom() == null) {
-            periode = DatoIntervallEntitet.fraOgMed(arbeidsavtale.getArbeidsavtaleFom());
+            periode = IntervallEntitet.fraOgMed(arbeidsavtale.getArbeidsavtaleFom());
         } else {
-            periode = DatoIntervallEntitet.fraOgMedTilOgMed(arbeidsavtale.getArbeidsavtaleFom(), arbeidsavtale.getArbeidsavtaleTom());
+            periode = IntervallEntitet.fraOgMedTilOgMed(arbeidsavtale.getArbeidsavtaleFom(), arbeidsavtale.getArbeidsavtaleTom());
         }
         AktivitetsAvtaleBuilder aktivitetsAvtaleBuilder = yrkesaktivitetBuilder.getAktivitetsAvtaleBuilder(periode, arbeidsavtale.getErAnsettelsesPerioden());
         aktivitetsAvtaleBuilder

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/IAYRegisterInnhentingFellesTjenesteImpl.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/IAYRegisterInnhentingFellesTjenesteImpl.java
@@ -36,6 +36,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektsKilde;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.SkatteOgAvgiftsregelType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kobling.KoblingReferanse;
@@ -57,7 +58,6 @@ import no.nav.foreldrepenger.abakus.typer.OrganisasjonsNummerValidator;
 import no.nav.foreldrepenger.abakus.typer.PersonIdent;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
 import no.nav.vedtak.felles.integrasjon.aktør.klient.AktørConsumer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public abstract class IAYRegisterInnhentingFellesTjenesteImpl implements IAYRegisterInnhentingTjeneste {
 
@@ -91,13 +91,13 @@ public abstract class IAYRegisterInnhentingFellesTjenesteImpl implements IAYRegi
     }
 
     private void innhentNæringsOpplysninger(Kobling kobling, InntektArbeidYtelseAggregatBuilder inntektArbeidYtelseAggregatBuilder) {
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = sigrunTjeneste.beregnetSkatt(kobling.getAktørId());
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = sigrunTjeneste.beregnetSkatt(kobling.getAktørId());
         InntektArbeidYtelseAggregatBuilder.AktørInntektBuilder aktørInntektBuilder = inntektArbeidYtelseAggregatBuilder
             .getAktørInntektBuilder(kobling.getAktørId());
 
         InntektBuilder inntektBuilder = aktørInntektBuilder.getInntektBuilder(InntektsKilde.SIGRUN, null);
 
-        for (Map.Entry<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> entry : map.entrySet()) {
+        for (Map.Entry<IntervallEntitet, Map<InntektspostType, BigDecimal>> entry : map.entrySet()) {
             for (Map.Entry<InntektspostType, BigDecimal> type : entry.getValue().entrySet()) {
                 InntektspostBuilder inntektspostBuilder = inntektBuilder.getInntektspostBuilder();
                 inntektspostBuilder
@@ -353,11 +353,11 @@ public abstract class IAYRegisterInnhentingFellesTjenesteImpl implements IAYRegi
 
     private AktivitetsAvtaleBuilder opprettAktivitetsAvtaleFrilans(FrilansArbeidsforhold frilansArbeidsforhold,
                                                                    YrkesaktivitetBuilder yrkesaktivitetBuilder) {
-        DatoIntervallEntitet periode;
+        IntervallEntitet periode;
         if (frilansArbeidsforhold.getTom() == null || frilansArbeidsforhold.getTom().isBefore(frilansArbeidsforhold.getFom())) {
-            periode = DatoIntervallEntitet.fraOgMed(frilansArbeidsforhold.getFom());
+            periode = IntervallEntitet.fraOgMed(frilansArbeidsforhold.getFom());
         } else {
-            periode = DatoIntervallEntitet.fraOgMedTilOgMed(frilansArbeidsforhold.getFom(), frilansArbeidsforhold.getTom());
+            periode = IntervallEntitet.fraOgMedTilOgMed(frilansArbeidsforhold.getFom(), frilansArbeidsforhold.getTom());
         }
         return yrkesaktivitetBuilder.getAktivitetsAvtaleBuilder(periode, true);
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTilInternMapper.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTilInternMapper.java
@@ -13,23 +13,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.vedtak.felles.integrasjon.sigrun.BeregnetSkatt;
 import no.nav.vedtak.felles.integrasjon.sigrun.summertskattegrunnlag.SSGGrunnlag;
 import no.nav.vedtak.felles.integrasjon.sigrun.summertskattegrunnlag.SSGResponse;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 class SigrunTilInternMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(SigrunTilInternMapper.class);
 
-    static Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> mapFraSigrunTilIntern(Map<Year, List<BeregnetSkatt>> beregnetSkatt, Map<Year, Optional<SSGResponse>> summertskattegrunnlagMap) {
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap = new HashMap<>();
+    static Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> mapFraSigrunTilIntern(Map<Year, List<BeregnetSkatt>> beregnetSkatt, Map<Year, Optional<SSGResponse>> summertskattegrunnlagMap) {
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap = new HashMap<>();
 
         mapBeregnetSkatt(beregnetSkatt, årTilInntektMap);
         mapSummertskattegrunnlag(summertskattegrunnlagMap, årTilInntektMap);
         return årTilInntektMap;
     }
 
-    private static void mapSummertskattegrunnlag(Map<Year, Optional<SSGResponse>> summertskattegrunnlagMap, Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap) {
+    private static void mapSummertskattegrunnlag(Map<Year, Optional<SSGResponse>> summertskattegrunnlagMap, Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap) {
         if (!summertskattegrunnlagMap.isEmpty()) {
             Set<Map.Entry<Year, Optional<SSGResponse>>> entrySet = summertskattegrunnlagMap.entrySet();
             for (Map.Entry<Year, Optional<SSGResponse>> entry : entrySet) {
@@ -41,7 +41,7 @@ class SigrunTilInternMapper {
                         .filter(f -> TekniskNavn.fraKode(f.getTekniskNavn()) != null)
                         .findFirst();
                     ssggrunnlag.ifPresent(grunnlag -> {
-                        DatoIntervallEntitet datoIntervallEntitet = lagDatoIntervall(entry.getKey());
+                        IntervallEntitet datoIntervallEntitet = lagDatoIntervall(entry.getKey());
                         InntektspostType inntektspostType = TekniskNavn.fraKode(grunnlag.getTekniskNavn()).getInntektspostType();
                         Map<InntektspostType, BigDecimal> inntektspost = årTilInntektMap.get(datoIntervallEntitet);
                         if (inntektspost == null) {
@@ -63,9 +63,9 @@ class SigrunTilInternMapper {
         }
     }
 
-    private static void mapBeregnetSkatt(Map<Year, List<BeregnetSkatt>> beregnetSkatt, Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap) {
+    private static void mapBeregnetSkatt(Map<Year, List<BeregnetSkatt>> beregnetSkatt, Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> årTilInntektMap) {
         for (Map.Entry<Year, List<BeregnetSkatt>> entry : beregnetSkatt.entrySet()) {
-            DatoIntervallEntitet intervallEntitet = lagDatoIntervall(entry.getKey());
+            IntervallEntitet intervallEntitet = lagDatoIntervall(entry.getKey());
             Map<InntektspostType, BigDecimal> typeTilVerdiMap = new HashMap<>();
             for (BeregnetSkatt beregnetSkatteobjekt : entry.getValue()) {
                 InntektspostType type = TekniskNavn.fraKode(beregnetSkatteobjekt.getTekniskNavn()).getInntektspostType();
@@ -82,9 +82,9 @@ class SigrunTilInternMapper {
         }
     }
 
-    private static DatoIntervallEntitet lagDatoIntervall(Year år) {
+    private static IntervallEntitet lagDatoIntervall(Year år) {
         LocalDateTime førsteDagIÅret = LocalDateTime.now().withYear(år.getValue()).withDayOfYear(1);
         LocalDateTime sisteDagIÅret = LocalDateTime.now().withYear(år.getValue()).withDayOfYear(år.length());
-        return DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅret.toLocalDate(), sisteDagIÅret.toLocalDate());
+        return IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅret.toLocalDate(), sisteDagIÅret.toLocalDate());
     }
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTjeneste.java
@@ -9,16 +9,17 @@ import java.util.Map;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.finn.unleash.Unleash;
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.vedtak.felles.integrasjon.sigrun.BeregnetSkatt;
 import no.nav.vedtak.felles.integrasjon.sigrun.SigrunConsumer;
 import no.nav.vedtak.felles.integrasjon.sigrun.SigrunResponse;
 import no.nav.vedtak.felles.integrasjon.sigrun.summertskattegrunnlag.SigrunSummertSkattegrunnlagResponse;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @ApplicationScoped
@@ -38,7 +39,7 @@ public class SigrunTjeneste {
         this.unleash = unleash;
     }
 
-    public Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> beregnetSkatt(AktørId aktørId) {
+    public Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> beregnetSkatt(AktørId aktørId) {
         SigrunResponse beregnetskatt;
         if (unleash.isEnabled("fpsak.sigrun.logg.respons", false)) {
             beregnetskatt = sigrunConsumer.beregnetskattMedLogging(Long.valueOf(aktørId.getId()));

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/tjeneste/InnhentRegisterdataTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/tjeneste/InnhentRegisterdataTjeneste.java
@@ -18,9 +18,9 @@ import no.nav.abakus.iaygrunnlag.kodeverk.RegisterdataType;
 import no.nav.abakus.iaygrunnlag.request.InnhentRegisterdataRequest;
 import no.nav.abakus.prosesstask.batch.BatchProsessTaskRepository;
 import no.nav.foreldrepenger.abakus.domene.iay.GrunnlagReferanse;
-import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseAggregatBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlagBuilder;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kobling.KoblingReferanse;
@@ -33,7 +33,6 @@ import no.nav.foreldrepenger.abakus.registerdata.RegisterdataInnhentingTask;
 import no.nav.foreldrepenger.abakus.registerdata.callback.CallbackTask;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
@@ -126,11 +125,11 @@ public class InnhentRegisterdataTjeneste {
         }
         Periode opplysningsperiode = dto.getOpplysningsperiode();
         if (opplysningsperiode != null) {
-            kobling.setOpplysningsperiode(DatoIntervallEntitet.fraOgMedTilOgMed(opplysningsperiode.getFom(), opplysningsperiode.getTom()));
+            kobling.setOpplysningsperiode(IntervallEntitet.fraOgMedTilOgMed(opplysningsperiode.getFom(), opplysningsperiode.getTom()));
         }
         Periode opptjeningsperiode = dto.getOpptjeningsperiode();
         if (opptjeningsperiode != null) {
-            kobling.setOpptjeningsperiode(DatoIntervallEntitet.fraOgMedTilOgMed(opptjeningsperiode.getFom(), opptjeningsperiode.getTom()));
+            kobling.setOpptjeningsperiode(IntervallEntitet.fraOgMedTilOgMed(opptjeningsperiode.getFom(), opptjeningsperiode.getTom()));
         }
         // Diff & log endringer
         koblingTjeneste.lagre(kobling);

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/domene/iay/InntektArbeidYtelseRepositoryTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/domene/iay/InntektArbeidYtelseRepositoryTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.inntektsmelding.InntektsmeldingBu
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.ArbeidType;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.OppgittAnnenAktivitetEntitet;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.OppgittOpptjeningBuilder;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kobling.KoblingReferanse;
 import no.nav.foreldrepenger.abakus.kobling.repository.KoblingRepository;
@@ -25,7 +26,6 @@ import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.OrgNummer;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.felles.testutilities.db.RepositoryRule;
 
 public class InntektArbeidYtelseRepositoryTest {
@@ -40,11 +40,11 @@ public class InntektArbeidYtelseRepositoryTest {
     public void skal_svare_om_er_siste() {
         final var ko = new Kobling(new Saksnummer("12341234"), new KoblingReferanse(UUID.randomUUID()), new AktørId("1231231231223"));
         ko.setYtelseType(YtelseType.PÅRØRENDESYKDOM);
-        ko.setOpplysningsperiode(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(2), LocalDate.now()));
+        ko.setOpplysningsperiode(IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(2), LocalDate.now()));
         koblingRepository.lagre(ko);
 
         final var builder = OppgittOpptjeningBuilder.ny();
-        builder.leggTilAnnenAktivitet(new OppgittAnnenAktivitetEntitet(DatoIntervallEntitet.fraOgMed(LocalDate.now()), ArbeidType.VENTELØNN_VARTPENGER));
+        builder.leggTilAnnenAktivitet(new OppgittAnnenAktivitetEntitet(IntervallEntitet.fraOgMed(LocalDate.now()), ArbeidType.VENTELØNN_VARTPENGER));
 
         final var grunnlagReferanse = repository.lagre(ko.getKoblingReferanse(), builder);
 

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterinnhentingTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/YtelseRegisterinnhentingTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseAggregatBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.Ytelse;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
@@ -27,7 +28,6 @@ import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseEntitet;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
 import no.nav.foreldrepenger.abakus.vedtak.domene.YtelseAnvistBuilder;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class YtelseRegisterinnhentingTest {
 
@@ -46,17 +46,17 @@ public class YtelseRegisterinnhentingTest {
     public void skal_gjenskape_feil() throws Exception {
         // Arrange
         VedtakYtelseEntitet vy = (VedtakYtelseEntitet)VedtakYtelseBuilder.oppdatere(Optional.empty())
-            .medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(4), LocalDate.now().minusMonths(2)))
+            .medPeriode(IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(4), LocalDate.now().minusMonths(2)))
             .medAktør(AktørId.dummy())
             .medStatus(YtelseStatus.AVSLUTTET)
             .medSaksnummer(new Saksnummer("123"))
             .medKilde(Fagsystem.FPSAK)
             .medYtelseType(YtelseType.ENGANGSTØNAD)
             .medBehandlingsTema(TemaUnderkategori.ENGANGSSTONAD_FODSEL)
-            .leggTil(YtelseAnvistBuilder.ny().medAnvistPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(4), LocalDate.now().minusMonths(2))))
+            .leggTil(YtelseAnvistBuilder.ny().medAnvistPeriode(IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(4), LocalDate.now().minusMonths(2))))
             .build();
         Kobling k = new Kobling();
-        k.setOpplysningsperiode(DatoIntervallEntitet.fraOgMed(LocalDate.now().minusMonths(17)));
+        k.setOpplysningsperiode(IntervallEntitet.fraOgMed(LocalDate.now().minusMonths(17)));
         when(samletTjeneste.hentYtelserTjenester(any(), any())).thenReturn(Collections.emptyList());
         when(samletTjeneste.innhentInfotrygdGrunnlag(any(), any())).thenReturn(Collections.emptyList());
         when(vedtakYtelseRepository.hentYtelserForIPeriode(any(), any(), any())).thenReturn(List.of(vy));

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTilInternMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/sigrun/SigrunTilInternMapperTest.java
@@ -14,10 +14,10 @@ import java.util.Optional;
 import org.junit.Test;
 
 import no.nav.foreldrepenger.abakus.domene.iay.kodeverk.InntektspostType;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.vedtak.felles.integrasjon.sigrun.BeregnetSkatt;
 import no.nav.vedtak.felles.integrasjon.sigrun.summertskattegrunnlag.SSGGrunnlag;
 import no.nav.vedtak.felles.integrasjon.sigrun.summertskattegrunnlag.SSGResponse;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class SigrunTilInternMapperTest {
     @Test
@@ -30,11 +30,11 @@ public class SigrunTilInternMapperTest {
         beregnet.put(iÅr, List.of(new BeregnetSkatt(TekniskNavn.PERSONINNTEKT_LØNN.getKode(), "5000")));
         summertskattegrunnlag.put(iÅr, Optional.of(new SSGResponse(List.of(), List.of(new SSGGrunnlag(TekniskNavn.LØNNSINNTEKT_MED_TRYGDEAVGIFTSPLIKT_OMFATTET_AV_LØNNSTREKKORDNINGEN.getKode(), "5000")), null)));
 
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
         LocalDate førsteDagIÅr = LocalDate.of(iÅr.getValue(), 1, 1);
         LocalDate sisteDagIÅr = LocalDate.of(iÅr.getValue(), 12, 31);
 
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(10000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(10000));
     }
 
     @Test
@@ -46,11 +46,11 @@ public class SigrunTilInternMapperTest {
         Year iÅr = Year.of(iDag.getYear());
         summertskattegrunnlag.put(iÅr, Optional.of(new SSGResponse(List.of(), List.of(new SSGGrunnlag(TekniskNavn.LØNNSINNTEKT_MED_TRYGDEAVGIFTSPLIKT_OMFATTET_AV_LØNNSTREKKORDNINGEN.getKode(), "5000")), null)));
 
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
         LocalDate førsteDagIÅr = LocalDate.of(iÅr.getValue(), 1, 1);
         LocalDate sisteDagIÅr = LocalDate.of(iÅr.getValue(), 12, 31);
 
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(5000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(5000));
     }
 
     @Test
@@ -63,11 +63,11 @@ public class SigrunTilInternMapperTest {
         beregnet.put(iÅr, List.of(new BeregnetSkatt(TekniskNavn.PERSONINNTEKT_LØNN.getKode(), "5000"), new BeregnetSkatt(TekniskNavn.SKATTEOPPGJØRSDATO.getKode(), "2018-10-04")));
         summertskattegrunnlag.put(iÅr, Optional.of(new SSGResponse(List.of(), List.of(new SSGGrunnlag(TekniskNavn.LØNNSINNTEKT_MED_TRYGDEAVGIFTSPLIKT_OMFATTET_AV_LØNNSTREKKORDNINGEN.getKode(), "5000")), null)));
 
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
         LocalDate førsteDagIÅr = LocalDate.of(iÅr.getValue(), 1, 1);
         LocalDate sisteDagIÅr = LocalDate.of(iÅr.getValue(), 12, 31);
 
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(10000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(10000));
     }
 
     @Test
@@ -80,12 +80,12 @@ public class SigrunTilInternMapperTest {
         beregnet.put(iÅr, List.of(new BeregnetSkatt(TekniskNavn.PERSONINNTEKT_FISKE_FANGST_FAMILIEBARNEHAGE.getKode(), "5000")));
         summertskattegrunnlag.put(iÅr, Optional.of(new SSGResponse(List.of(), List.of(new SSGGrunnlag(TekniskNavn.LØNNSINNTEKT_MED_TRYGDEAVGIFTSPLIKT_OMFATTET_AV_LØNNSTREKKORDNINGEN.getKode(), "5000")), null)));
 
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
         LocalDate førsteDagIÅr = LocalDate.of(iÅr.getValue(), 1, 1);
         LocalDate sisteDagIÅr = LocalDate.of(iÅr.getValue(), 12, 31);
 
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(5000));
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.NÆRING_FISKE_FANGST_FAMBARNEHAGE)).isEqualByComparingTo(new BigDecimal(5000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(5000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.NÆRING_FISKE_FANGST_FAMBARNEHAGE)).isEqualByComparingTo(new BigDecimal(5000));
     }
 
     @Test
@@ -98,10 +98,10 @@ public class SigrunTilInternMapperTest {
         beregnet.put(iÅr, List.of(new BeregnetSkatt(TekniskNavn.PERSONINNTEKT_LØNN.getKode(), "5000"), new BeregnetSkatt(TekniskNavn.PERSONINNTEKT_BARE_PENSJONSDEL.getKode(), "5000"), new BeregnetSkatt(TekniskNavn.SKATTEOPPGJØRSDATO.getKode(), "2018-10-04")));
         summertskattegrunnlag.put(iÅr, Optional.of(new SSGResponse(List.of(), List.of(new SSGGrunnlag(TekniskNavn.LØNNSINNTEKT_MED_TRYGDEAVGIFTSPLIKT_OMFATTET_AV_LØNNSTREKKORDNINGEN.getKode(), "5000")), null)));
 
-        Map<DatoIntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
+        Map<IntervallEntitet, Map<InntektspostType, BigDecimal>> map = SigrunTilInternMapper.mapFraSigrunTilIntern(beregnet, summertskattegrunnlag);
         LocalDate førsteDagIÅr = LocalDate.of(iÅr.getValue(), 1, 1);
         LocalDate sisteDagIÅr = LocalDate.of(iÅr.getValue(), 12, 31);
 
-        assertThat(map.get(DatoIntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(15000));
+        assertThat(map.get(IntervallEntitet.fraOgMedTilOgMed(førsteDagIÅr, sisteDagIÅr)).get(InntektspostType.LØNN)).isEqualByComparingTo(new BigDecimal(15000));
     }
 }

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/InfotrygdTjenesteImplTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/InfotrygdTjenesteImplTest.java
@@ -12,9 +12,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import no.nav.foreldrepenger.abakus.dbstoette.UnittestRepositoryRule;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.registerdata.ytelse.infotrygd.InnhentingInfotrygdTjeneste;
 import no.nav.foreldrepenger.abakus.typer.PersonIdent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.felles.testutilities.cdi.CdiRunner;
 import no.nav.vedtak.felles.testutilities.db.RepositoryRule;
 
@@ -33,7 +33,7 @@ public class InfotrygdTjenesteImplTest {
     @Test
     public void skal_kalle_consumer_og_oversette_response() throws Exception {
         // Arrange
-        var response = samletTjeneste.getInfotrygdYtelser(PersonIdent.fra(FNR), DatoIntervallEntitet.fraOgMed(KONFIG_FOM).tilIntervall());
+        var response = samletTjeneste.getInfotrygdYtelser(PersonIdent.fra(FNR), IntervallEntitet.fraOgMed(KONFIG_FOM).tilIntervall());
         assertThat(response).isEmpty();
     }
 

--- a/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/diff/TraverseEntityGraphFactory.java
+++ b/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/diff/TraverseEntityGraphFactory.java
@@ -5,10 +5,9 @@ import java.util.function.Function;
 import no.nav.foreldrepenger.abakus.felles.diff.TraverseGraph;
 import no.nav.foreldrepenger.abakus.felles.diff.TraverseGraphConfig;
 import no.nav.foreldrepenger.abakus.felles.diff.TraverseJpaEntityGraphConfig;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kodeverk.Kodeverdi;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
-import no.nav.vedtak.felles.jpa.tid.ÅpenDatoIntervallEntitet;
 
 /*
  * Legger denne sammen med RootClass
@@ -28,7 +27,7 @@ public final class TraverseEntityGraphFactory {
         config.setOnlyCheckTrackedFields(medChangedTrackedOnly);
         
         config.addLeafClasses(Kodeverdi.class);
-        config.addLeafClasses(DatoIntervallEntitet.class, ÅpenDatoIntervallEntitet.class);
+        config.addLeafClasses(IntervallEntitet.class);
         
         config.addRootClasses(Kobling.class);
         config.setInclusionFilter(inclusionFilter);

--- a/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/kobling/Kobling.java
+++ b/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/kobling/Kobling.java
@@ -19,10 +19,10 @@ import javax.persistence.Version;
 import org.hibernate.annotations.NaturalId;
 
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "Kobling")
 @Table(name = "KOBLING")
@@ -69,14 +69,14 @@ public class Kobling extends no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet
         @AttributeOverride(name = "fomDato", column = @Column(name = "opplysning_periode_fom")),
         @AttributeOverride(name = "tomDato", column = @Column(name = "opplysning_periode_tom"))
     })
-    private DatoIntervallEntitet opplysningsperiode;
+    private IntervallEntitet opplysningsperiode;
 
     @Embedded
     @AttributeOverrides({
         @AttributeOverride(name = "fomDato", column = @Column(name = "opptjening_periode_fom")),
         @AttributeOverride(name = "tomDato", column = @Column(name = "opptjening_periode_tom"))
     })
-    private DatoIntervallEntitet opptjeningsperiode;
+    private IntervallEntitet opptjeningsperiode;
 
     @Version
     @Column(name = "versjon", nullable = false)
@@ -123,19 +123,19 @@ public class Kobling extends no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet
         return opplysningsperiode.getFomDato().plusDays(1);
     }
 
-    public DatoIntervallEntitet getOpplysningsperiode() {
+    public IntervallEntitet getOpplysningsperiode() {
         return opplysningsperiode;
     }
 
-    public void setOpplysningsperiode(DatoIntervallEntitet opplysningsperiode) {
+    public void setOpplysningsperiode(IntervallEntitet opplysningsperiode) {
         this.opplysningsperiode = opplysningsperiode;
     }
 
-    public DatoIntervallEntitet getOpptjeningsperiode() {
+    public IntervallEntitet getOpptjeningsperiode() {
         return opptjeningsperiode;
     }
 
-    public void setOpptjeningsperiode(DatoIntervallEntitet opptjeningsperiode) {
+    public void setOpptjeningsperiode(IntervallEntitet opptjeningsperiode) {
         this.opptjeningsperiode = opptjeningsperiode;
     }
 

--- a/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/kobling/repository/KoblingRepository.java
+++ b/domenetjenester/kobling/src/main/java/no/nav/foreldrepenger/abakus/kobling/repository/KoblingRepository.java
@@ -16,6 +16,7 @@ import no.nav.foreldrepenger.abakus.felles.diff.DiffEntity;
 import no.nav.foreldrepenger.abakus.felles.diff.DiffResult;
 import no.nav.foreldrepenger.abakus.felles.diff.TraverseGraph;
 import no.nav.foreldrepenger.abakus.felles.diff.TraverseJpaEntityGraphConfig;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kobling.Kobling;
 import no.nav.foreldrepenger.abakus.kobling.KoblingReferanse;
 import no.nav.foreldrepenger.abakus.kodeverk.Kodeliste;
@@ -25,8 +26,6 @@ import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.HibernateVerktøy;
 import no.nav.vedtak.felles.jpa.VLPersistenceUnit;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
-import no.nav.vedtak.felles.jpa.tid.ÅpenDatoIntervallEntitet;
 
 @ApplicationScoped
 public class KoblingRepository {
@@ -86,7 +85,7 @@ public class KoblingRepository {
         config.setOnlyCheckTrackedFields(false);
         config.addLeafClasses(KodeverkTabell.class);
         config.addLeafClasses(Kodeliste.class);
-        config.addLeafClasses(DatoIntervallEntitet.class, ÅpenDatoIntervallEntitet.class);
+        config.addLeafClasses(IntervallEntitet.class);
         var diffEntity = new DiffEntity(new TraverseGraph(config));
 
         return diffEntity.diff(eksisterendeKobling, nyKobling);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseBuilder.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseBuilder.java
@@ -5,12 +5,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class VedtakYtelseBuilder {
 
@@ -59,7 +59,7 @@ public class VedtakYtelseBuilder {
         return this;
     }
 
-    public VedtakYtelseBuilder medPeriode(DatoIntervallEntitet intervallEntitet) {
+    public VedtakYtelseBuilder medPeriode(IntervallEntitet intervallEntitet) {
         ytelse.setPeriode(intervallEntitet);
         return this;
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseEntitet.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseEntitet.java
@@ -28,13 +28,13 @@ import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.DiffIgnore;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "VedtakYtelseEntitet")
 @Table(name = "VEDTAK_YTELSE")
@@ -62,7 +62,7 @@ public class VedtakYtelseEntitet extends BaseEntitet implements VedtattYtelse, I
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet periode;
+    private IntervallEntitet periode;
 
     @ChangeTracked
     @Convert(converter = YtelseStatus.KodeverdiConverter.class)
@@ -160,11 +160,11 @@ public class VedtakYtelseEntitet extends BaseEntitet implements VedtattYtelse, I
     }
 
     @Override
-    public DatoIntervallEntitet getPeriode() {
+    public IntervallEntitet getPeriode() {
         return periode;
     }
 
-    void setPeriode(DatoIntervallEntitet periode) {
+    void setPeriode(IntervallEntitet periode) {
         this.periode = periode;
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtattYtelse.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtattYtelse.java
@@ -4,12 +4,12 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.UUID;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public interface VedtattYtelse {
 
@@ -21,7 +21,7 @@ public interface VedtattYtelse {
 
     YtelseStatus getStatus();
 
-    DatoIntervallEntitet getPeriode();
+    IntervallEntitet getPeriode();
 
     Saksnummer getSaksnummer();
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistBuilder.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistBuilder.java
@@ -2,9 +2,9 @@ package no.nav.foreldrepenger.abakus.vedtak.domene;
 
 import java.math.BigDecimal;
 
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 public class YtelseAnvistBuilder {
     private final YtelseAnvistEntitet ytelseAnvistEntitet;
@@ -31,7 +31,7 @@ public class YtelseAnvistBuilder {
         return this;
     }
 
-    public YtelseAnvistBuilder medAnvistPeriode(DatoIntervallEntitet intervallEntitet) {
+    public YtelseAnvistBuilder medAnvistPeriode(IntervallEntitet intervallEntitet) {
         this.ytelseAnvistEntitet.setAnvistPeriode(intervallEntitet);
         return this;
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistEntitet.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistEntitet.java
@@ -20,9 +20,9 @@ import javax.persistence.Version;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @Entity(name = "VedtakYtelseAnvistEntitet")
 @Table(name = "VE_YTELSE_ANVIST")
@@ -38,7 +38,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
 
     @Embedded
     @ChangeTracked
-    private DatoIntervallEntitet anvistPeriode;
+    private IntervallEntitet anvistPeriode;
 
     @Embedded
     @AttributeOverrides(@AttributeOverride(name = "verdi", column = @Column(name = "beloep")))
@@ -64,7 +64,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
     }
 
     public YtelseAnvistEntitet(YtelseAnvist ytelseAnvist) {
-        this.anvistPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(ytelseAnvist.getAnvistFom(), ytelseAnvist.getAnvistTom());
+        this.anvistPeriode = IntervallEntitet.fraOgMedTilOgMed(ytelseAnvist.getAnvistFom(), ytelseAnvist.getAnvistTom());
         this.beløp = ytelseAnvist.getBeløp().orElse(null);
         this.dagsats = ytelseAnvist.getDagsats().orElse(null);
         this.utbetalingsgradProsent = ytelseAnvist.getUtbetalingsgradProsent().orElse(null);
@@ -112,7 +112,7 @@ public class YtelseAnvistEntitet extends BaseEntitet implements YtelseAnvist, In
         this.dagsats = dagsats;
     }
 
-    void setAnvistPeriode(DatoIntervallEntitet periode) {
+    void setAnvistPeriode(IntervallEntitet periode) {
         this.anvistPeriode = periode;
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
@@ -9,6 +9,7 @@ import no.nav.abakus.vedtak.ytelse.Periode;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseType;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
@@ -17,7 +18,6 @@ import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
 import no.nav.foreldrepenger.abakus.vedtak.domene.YtelseAnvistBuilder;
 import no.nav.foreldrepenger.abakus.vedtak.extract.ExtractFromYtelse;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 
 @ApplicationScoped
 public class ExtractFromYtelseV1 implements ExtractFromYtelse<YtelseV1> {
@@ -68,8 +68,8 @@ public class ExtractFromYtelseV1 implements ExtractFromYtelse<YtelseV1> {
         builder.leggTil(anvistBuilder);
     }
 
-    private DatoIntervallEntitet mapTilEntitet(Periode periode) {
-        return DatoIntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
+    private IntervallEntitet mapTilEntitet(Periode periode) {
+        return IntervallEntitet.fraOgMedTilOgMed(periode.getFom(), periode.getTom());
     }
 
     private no.nav.foreldrepenger.abakus.kodeverk.YtelseType getYtelseType(YtelseType kodeverk) {

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseRepositoryTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseRepositoryTest.java
@@ -10,12 +10,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import no.nav.foreldrepenger.abakus.dbstoette.UnittestRepositoryRule;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseStatus;
 import no.nav.foreldrepenger.abakus.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Fagsystem;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
 import no.nav.vedtak.felles.testutilities.db.RepositoryRule;
 
 public class VedtakYtelseRepositoryTest {
@@ -31,7 +31,7 @@ public class VedtakYtelseRepositoryTest {
         final var saksnummer = new Saksnummer("1234");
         final var builder = repository.opprettBuilderFor(aktørId, saksnummer, Fagsystem.FPSAK, YtelseType.FORELDREPENGER);
 
-        builder.medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(1), LocalDate.now()))
+        builder.medPeriode(IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(1), LocalDate.now()))
             .medStatus(YtelseStatus.LØPENDE)
             .medVedtakReferanse(UUID.randomUUID())
             .medVedtattTidspunkt(LocalDateTime.now());
@@ -42,7 +42,7 @@ public class VedtakYtelseRepositoryTest {
         assertThat(vedtattYtelser).hasSize(1);
 
         final var nyBuilder = repository.opprettBuilderFor(aktørId, saksnummer, Fagsystem.FPSAK, YtelseType.FORELDREPENGER);
-        final var intervallEntitet = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusMonths(3));
+        final var intervallEntitet = IntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusMonths(3));
         nyBuilder.medVedtakReferanse(UUID.randomUUID())
             .medVedtattTidspunkt(LocalDateTime.now())
             .medPeriode(intervallEntitet);
@@ -62,7 +62,7 @@ public class VedtakYtelseRepositoryTest {
         final var saksnummer = new Saksnummer("1234");
         final var builder = repository.opprettBuilderFor(aktørId, saksnummer, Fagsystem.FPSAK, YtelseType.FORELDREPENGER);
 
-        builder.medPeriode(DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(1), LocalDate.now()))
+        builder.medPeriode(IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusYears(1), LocalDate.now()))
             .medStatus(YtelseStatus.LØPENDE)
             .medVedtakReferanse(UUID.randomUUID())
             .medVedtattTidspunkt(LocalDateTime.now());
@@ -73,7 +73,7 @@ public class VedtakYtelseRepositoryTest {
         assertThat(vedtattYtelser).hasSize(1);
 
         final var nyBuilder = repository.opprettBuilderFor(aktørId, saksnummer, Fagsystem.FPSAK, YtelseType.FORELDREPENGER);
-        final var intervallEntitet = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusMonths(3));
+        final var intervallEntitet = IntervallEntitet.fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusMonths(3));
         nyBuilder.medVedtakReferanse(UUID.randomUUID())
             .medVedtattTidspunkt(LocalDateTime.now().minusMinutes(10))
             .medStatus(YtelseStatus.LØPENDE)

--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/diff/IndexKeyComposer.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/diff/IndexKeyComposer.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import no.nav.vedtak.felles.jpa.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 
 /**
  * Hjelpemetoder for å raskere sette sammen en IndexKey fra flere deler.
@@ -42,8 +42,8 @@ final class IndexKeyComposer {
             return ((Number) obj).toString();
         } else if (IndexKey.class.isAssignableFrom(objClass)) {
             return ((IndexKey) obj).getIndexKey();
-        } else if (DatoIntervallEntitet.class.isAssignableFrom(objClass)) {
-            DatoIntervallEntitet periode = (DatoIntervallEntitet) obj;
+        } else if (IntervallEntitet.class.isAssignableFrom(objClass)) {
+            IntervallEntitet periode = (IntervallEntitet) obj;
             return "[" + periode.getFomDato().format(DateTimeFormatter.ISO_DATE) + //$NON-NLS-1$
                 "," + periode.getTomDato().format(DateTimeFormatter.ISO_DATE) + "]"; //$NON-NLS-1$ //$NON-NLS-2$
         } else if (LocalDate.class.isAssignableFrom(objClass)) {

--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/jpa/AbstractIntervall.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/jpa/AbstractIntervall.java
@@ -1,0 +1,79 @@
+package no.nav.foreldrepenger.abakus.felles.jpa;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import org.threeten.extra.Interval;
+
+import no.nav.vedtak.konfig.Tid;
+
+public abstract class AbstractIntervall implements Comparable<AbstractIntervall>, Serializable {
+
+    public static final LocalDate TIDENES_BEGYNNELSE = Tid.TIDENES_BEGYNNELSE;
+    public static final LocalDate TIDENES_ENDE = Tid.TIDENES_ENDE;
+
+    static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+
+    public abstract LocalDate getFomDato();
+
+    public abstract LocalDate getTomDato();
+
+
+    public Interval tilIntervall() {
+        return getIntervall(getFomDato(), getTomDato());
+    }
+
+    private static Interval getIntervall(LocalDate fomDato, LocalDate tomDato) {
+        LocalDateTime døgnstart = TIDENES_ENDE.equals(tomDato) ? tomDato.atStartOfDay() : tomDato.atStartOfDay().plusDays(1);
+        return Interval.of(
+            fomDato.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant(),
+            døgnstart.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    public boolean overlapper(AbstractIntervall periode) {
+        return tilIntervall().overlaps(getIntervall(periode.getFomDato(), periode.getTomDato()));
+    }
+
+    public boolean inkluderer(LocalDate dato) {
+        return erEtterEllerLikPeriodestart(dato) && erFørEllerLikPeriodeslutt(dato);
+    }
+
+    private boolean erEtterEllerLikPeriodestart(LocalDate dato) {
+        return getFomDato().isBefore(dato) || getFomDato().isEqual(dato);
+    }
+
+    private boolean erFørEllerLikPeriodeslutt(LocalDate dato) {
+        return getTomDato() == null || getTomDato().isAfter(dato) || getTomDato().isEqual(dato);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == this) {
+            return true;
+        }
+        if (!(object instanceof AbstractIntervall)) {
+            return false;
+        }
+        AbstractIntervall annen = (AbstractIntervall) object;
+        return this.getFomDato().equals(annen.getFomDato()) && this.getTomDato().equals(annen.getTomDato());
+    }
+
+    @Override
+    public int compareTo(AbstractIntervall periode) {
+        return getFomDato().compareTo(periode.getFomDato());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFomDato(), getTomDato());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Periode: %s - %s", getFomDato().format(FORMATTER), getTomDato().format(FORMATTER));
+    }
+}

--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/jpa/IntervallEntitet.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/jpa/IntervallEntitet.java
@@ -1,0 +1,54 @@
+package no.nav.foreldrepenger.abakus.felles.jpa;
+
+import java.time.LocalDate;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class IntervallEntitet extends AbstractIntervall {
+
+
+    @Column(name = "fom")
+    private LocalDate fomDato;
+
+    @Column(name = "tom")
+    private LocalDate tomDato;
+
+
+    public IntervallEntitet() {
+        //hibernate
+    }
+    private IntervallEntitet(LocalDate fomDato, LocalDate tomDato) {
+        if (fomDato == null) {
+            throw new IllegalArgumentException("Fra og med dato må være satt.");
+        } else if (tomDato == null) {
+            throw new IllegalArgumentException("Til og med dato må være satt.");
+        } else if (tomDato.isBefore(fomDato)) {
+            throw new IllegalArgumentException("Til og med dato før fra og med dato.");
+        } else {
+            this.fomDato = fomDato;
+            this.tomDato = tomDato;
+        }
+    }
+
+    public static IntervallEntitet fraOgMedTilOgMed(LocalDate fomDato, LocalDate tomDato) {
+        return new IntervallEntitet(fomDato, tomDato);
+    }
+
+    public static IntervallEntitet fraOgMed(LocalDate fomDato) {
+        return new IntervallEntitet(fomDato, TIDENES_ENDE);
+    }
+
+    public LocalDate getFomDato() {
+        return this.fomDato;
+    }
+
+    public LocalDate getTomDato() {
+        return this.tomDato;
+    }
+
+    protected IntervallEntitet lagNyPeriode(LocalDate fomDato, LocalDate tomDato) {
+        return fraOgMedTilOgMed(fomDato, tomDato);
+    }
+}


### PR DESCRIPTION
Øvelsen med å bruke IntervallEntitet istedenfor DatoIntervallEntitet fra fellse-db som er deprecated.
ÅpenDatoIntervallEntitet ble fjernet da denne var ikke i bruk.