### PR TITLE
NOJIRA endret datainnhold fra SPokelse

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/InnhentingInfotrygdTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/InnhentingInfotrygdTjeneste.java
@@ -259,7 +259,8 @@ public class InnhentingInfotrygdTjeneste {
             .medYtelseType(YtelseType.SYKEPENGER)
             .medTemaUnderkategori(TemaUnderkategori.SYKEPENGER_SYKEPENGER)
             .medYtelseStatus(YtelseStatus.AVSLUTTET)
-            .medIdentdato(grunnlag.getVedtaksreferanse())
+            .medVedtaksreferanse(grunnlag.getVedtaksreferanse())
+            .medIdentdato(grunnlag.getVedtattTidspunkt() != null ? grunnlag.getVedtattTidspunkt().toLocalDate() : LocalDate.now())
             .medVedtaksPeriodeFom(brukPeriode.getFom())
             .medVedtaksPeriodeTom(brukPeriode.getTom());
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/dto/InfotrygdYtelseGrunnlag.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/dto/InfotrygdYtelseGrunnlag.java
@@ -20,6 +20,7 @@ public class InfotrygdYtelseGrunnlag {
     private List<InfotrygdYtelseAnvist> utbetaltePerioder;
     private LocalDate vedtaksPeriodeFom;
     private LocalDate vedtaksPeriodeTom;
+    private String vedtaksreferanse;
 
     private Arbeidskategori kategori;
     private List<InfotrygdYtelseArbeid> arbeidsforhold;
@@ -79,6 +80,10 @@ public class InfotrygdYtelseGrunnlag {
 
     public LocalDate getOpprinneligIdentdato() {
         return opprinneligIdentdato;
+    }
+
+    public String getVedtaksreferanse() {
+        return vedtaksreferanse;
     }
 
     @Override
@@ -210,6 +215,11 @@ public class InfotrygdYtelseGrunnlag {
 
         public Builder medOpprinneligIdentdato(LocalDate opprinneligIdentdato) {
             grunnlag.opprinneligIdentdato = opprinneligIdentdato;
+            return this;
+        }
+
+        public Builder medVedtaksreferanse(String vedtaksreferanse) {
+            grunnlag.vedtaksreferanse = vedtaksreferanse;
             return this;
         }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/spokelse/SykepengeVedtak.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/ytelse/infotrygd/spokelse/SykepengeVedtak.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.abakus.registerdata.ytelse.infotrygd.spokelse;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -17,23 +17,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class SykepengeVedtak {
 
     @JsonProperty("vedtaksreferanse")
-    private LocalDate vedtaksreferanse;
+    private String vedtaksreferanse;
     @JsonProperty("utbetalinger")
     private List<SykepengeUtbetaling> utbetalinger;
+    @JsonProperty("vedtattTidspunkt")
+    private LocalDateTime vedtattTidspunkt;
+
 
     @JsonCreator
-    public SykepengeVedtak(@JsonProperty("vedtaksreferanse") LocalDate vedtaksreferanse,
-                           @JsonProperty("utbetalinger") List<SykepengeUtbetaling> utbetalinger) {
+    public SykepengeVedtak(@JsonProperty("vedtaksreferanse") String vedtaksreferanse,
+                           @JsonProperty("utbetalinger") List<SykepengeUtbetaling> utbetalinger,
+                           @JsonProperty("vedtattTidspunkt") LocalDateTime vedtattTidspunkt) {
         this.vedtaksreferanse = vedtaksreferanse;
         this.utbetalinger = utbetalinger;
+        this.vedtattTidspunkt = vedtattTidspunkt;
     }
 
-    public LocalDate getVedtaksreferanse() {
+    public String getVedtaksreferanse() {
         return vedtaksreferanse;
     }
 
     public List<SykepengeUtbetaling> getUtbetalinger() {
         return utbetalinger != null ? utbetalinger : Collections.emptyList();
+    }
+
+    public LocalDateTime getVedtattTidspunkt() {
+        return vedtattTidspunkt;
     }
 
     @Override
@@ -42,19 +51,22 @@ public class SykepengeVedtak {
         if (o == null || getClass() != o.getClass()) return false;
         SykepengeVedtak that = (SykepengeVedtak) o;
         return Objects.equals(vedtaksreferanse, that.vedtaksreferanse) &&
-                Objects.equals(utbetalinger, that.utbetalinger);
+            Objects.equals(utbetalinger, that.utbetalinger) &&
+            Objects.equals(vedtattTidspunkt, that.vedtattTidspunkt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(vedtaksreferanse, utbetalinger);
+        return Objects.hash(vedtaksreferanse, utbetalinger, vedtattTidspunkt);
     }
 
     @Override
     public String toString() {
         return "SykepengeVedtak{" +
-                "vedtaksreferanse=" + vedtaksreferanse +
-                ", utbetalinger=" + utbetalinger +
-                '}';
+            "vedtaksreferanse='" + vedtaksreferanse + '\'' +
+            ", utbetalinger=" + utbetalinger +
+            ", vedtattTidspunkt=" + vedtattTidspunkt +
+            '}';
     }
+
 }


### PR DESCRIPTION
Først logge svar og forstå innholdskonvensjoner. SPokelse skal være oppdatert,
Litt avhengig av struktur på vedtaksreferanse kan den brukes som "kildesaksnummer" - trenger da en AktørYtelseBuilder a la den fra Arena isf Infotrygd (som mangler saksnummer). Relativt fort gjor når vi ser data.
