### PR TITLE
NOJIRA validering ytelsetype for tidlig i livssyklus til grunnlaget

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/InntektsmeldingerRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/InntektsmeldingerRestTjeneste.java
@@ -179,6 +179,7 @@ public class InntektsmeldingerRestTjeneste extends FellesRestTjeneste {
         switch (ytelseType) {
             case FORELDREPENGER:
             case SVANGERSKAPSPENGER:
+            case UDEFINERT:
                 // har ikke validering på Kapittel 14 ytelser her ennå pga feil i Gosys kopiering ved journalføring på annen sak.
                 return;
             default:


### PR DESCRIPTION
Kobling får ikke ytelsetype før ved registerinnhenting. Første IM lagres før dette -> ytelse = UDEFINERT.
Ytelse fra IM sendes ikke med i lagreIM-request ... 