### PR TITLE
NOJIRA logge innhold for priv ag og bedre sammenligning usorterte lister

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/Arbeidsforhold.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/Arbeidsforhold.java
@@ -68,9 +68,25 @@ public class Arbeidsforhold {
             Objects.equals(type, that.type) &&
             Objects.equals(arbeidFom, that.arbeidFom) &&
             Objects.equals(arbeidTom, that.arbeidTom) &&
-            Objects.equals(arbeidsavtaler, that.arbeidsavtaler) &&
-            Objects.equals(permisjoner, that.permisjoner) &&
+            erLikeArbeidsavtaler(arbeidsavtaler, that.arbeidsavtaler) &&
+            erLikePermisjoner(permisjoner, that.permisjoner) &&
             ((arbeidsgiver instanceof Organisasjon && Objects.equals(arbeidsforholdId, that.arbeidsforholdId)) || arbeidsgiver instanceof Person);
+    }
+
+    private boolean erLikeArbeidsavtaler(List<Arbeidsavtale> l1, List<Arbeidsavtale> l2) {
+        if (l1 == null && l2 == null)
+            return true;
+        if (l1 == null || l2 == null)
+            return true;
+        return l1.containsAll(l2) && l2.containsAll(l1);
+    }
+
+    private boolean erLikePermisjoner(List<Permisjon> l1, List<Permisjon> l2) {
+        if (l1 == null && l2 == null)
+            return true;
+        if (l1 == null || l2 == null)
+            return true;
+        return l1.containsAll(l2) && l2.containsAll(l1);
     }
 
     @Override

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/ArbeidsforholdTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/ArbeidsforholdTjeneste.java
@@ -302,6 +302,11 @@ public class ArbeidsforholdTjeneste {
 
     private void utledArbeidsgiverRS(ArbeidsforholdRS arbeidsforhold, Arbeidsforhold.Builder builder) {
         if (OpplysningspliktigArbeidsgiverRS.Type.Person.equals(arbeidsforhold.getArbeidsgiver().getType())) {
+            if (arbeidsforhold.getArbeidsgiver().getAktoerId() == null) {
+                LOGGER.info("ABAKUS AAREG RS privat ag uten aktoerId {}", arbeidsforhold.getArbeidsgiver());
+            } else {
+                LOGGER.info("ABAKUS AAREG RS privat ag med aktoerId");
+            }
             no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.Person person = new no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.Person.Builder()
                 .medAktørId(new AktørId(arbeidsforhold.getArbeidsgiver().getAktoerId()))
                 .build();

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/rest/OpplysningspliktigArbeidsgiverRS.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/rest/OpplysningspliktigArbeidsgiverRS.java
@@ -43,9 +43,10 @@ public class OpplysningspliktigArbeidsgiverRS {
     @Override
     public String toString() {
         return "OpplysningspliktigArbeidsgiverRS{" +
-                "type=" + type +
-                ", organisasjonsnummer='" + organisasjonsnummer + '\'' +
-                ", aktoerId='" + aktoerId + '\'' +
-                '}';
+            "type=" + type +
+            ", organisasjonsnummer='" + organisasjonsnummer + '\'' +
+            ", aktoerId='" + aktoerId + '\'' +
+            ", offentligIdent='" + offentligIdent + '\'' +
+            '}';
     }
 }


### PR DESCRIPTION
Finne ut hva vi får i tilfelle privat arbeidsgiver (aktoerId er null)
Permisjoner out of order gir falske avvik ved sammenligning av Lists