### PR TITLE
TFP-3988 swagger for innhenting av lønnkomp for utvalgte saker

### DIFF
--- a/domenetjenester/iay/pom.xml
+++ b/domenetjenester/iay/pom.xml
@@ -43,6 +43,10 @@
 			<groupId>no.nav.foreldrepenger.abakus</groupId>
 			<artifactId>vedtak</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.abakus</groupId>
+            <artifactId>lonnskomp</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
 			<artifactId>infotrygd-grunnlag-klient</artifactId>

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/IAYRegisterInnhentingFellesTjenesteImpl.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/IAYRegisterInnhentingFellesTjenesteImpl.java
@@ -280,6 +280,10 @@ public abstract class IAYRegisterInnhentingFellesTjenesteImpl implements IAYRegi
         var inntektsKilde = ELEMENT_TIL_INNTEKTS_KILDE_MAP.get(registerdataElement);
         var inntektsInformasjon = innhentingSamletTjeneste.getInntektsInformasjon(aktørId, kobling.getOpplysningsperiode().tilIntervall(), inntektsKilde, kobling.getYtelseType());
 
+        // En slags ytelse som er utbetalt fra NAV til bruker som LØNN ...
+        if (innhentingSamletTjeneste.skalInnhenteLønnskompensasjon(kobling.getSaksnummer(), inntektsKilde)) {
+            inntektsInformasjon.leggTilMånedsinntekter(innhentingSamletTjeneste.getLønnskompensasjon(aktørId, kobling.getOpplysningsperiode().tilIntervall()));
+        }
         if (informasjonsElementer.contains(registerdataElement)) {
             leggTilInntekter(aktørId, builder, inntektsInformasjon, kobling.getYtelseType());
         }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/komponenten/InntektsInformasjon.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/inntekt/komponenten/InntektsInformasjon.java
@@ -20,13 +20,18 @@ public class InntektsInformasjon {
     private InntektskildeType kilde;
 
     public InntektsInformasjon(List<Månedsinntekt> månedsinntekter, List<FrilansArbeidsforhold> frilansArbeidsforhold, InntektskildeType kilde) {
-        this.månedsinntekter = månedsinntekter;
+        this.månedsinntekter = new ArrayList<>();
+        this.månedsinntekter.addAll(månedsinntekter);
         this.frilansArbeidsforhold = frilansArbeidsforhold;
         this.kilde = kilde;
     }
 
     public List<Månedsinntekt> getMånedsinntekter() {
         return Collections.unmodifiableList(månedsinntekter);
+    }
+
+    public void leggTilMånedsinntekter(List<Månedsinntekt> inntekter) {
+        this.månedsinntekter.addAll(inntekter);
     }
 
     public Map<ArbeidsforholdIdentifikator, List<FrilansArbeidsforhold>> getFrilansArbeidsforhold() {

--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/InnhentingSamletTjenesteTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/InnhentingSamletTjenesteTest.java
@@ -1,0 +1,62 @@
+package no.nav.foreldrepenger.abakus.registerdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
+import no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonAnvist;
+import no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonRepository;
+import no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonVedtak;
+import no.nav.foreldrepenger.abakus.typer.AktørId;
+import no.nav.foreldrepenger.abakus.typer.Beløp;
+import no.nav.foreldrepenger.abakus.typer.OrgNummer;
+
+public class InnhentingSamletTjenesteTest {
+
+
+
+    private LønnskompensasjonRepository repository = mock(LønnskompensasjonRepository.class);
+
+    private InnhentingSamletTjeneste samletTjeneste;
+
+    @BeforeEach
+    public void before() {
+        samletTjeneste = new InnhentingSamletTjeneste(null, null, null, repository, null);
+    }
+
+    @Test
+    public void skal_telle_riktig_dager_og_fordele()  {
+        // Arrange
+        LocalDate fom = LocalDate.of(2020,5,15);
+        LocalDate tom = LocalDate.of(2020,6,10);
+        LønnskompensasjonVedtak lk = new LønnskompensasjonVedtak();
+        lk.setAktørId(AktørId.dummy());
+        lk.setOrgNummer(new OrgNummer("999999999"));
+        lk.setSakId(UUID.randomUUID().toString());
+        lk.setBeløp(new Beløp(new BigDecimal(30000L)));
+        lk.setPeriode(IntervallEntitet.fraOgMedTilOgMed(fom, tom));
+        lk.leggTilAnvistPeriode(LønnskompensasjonAnvist.LønnskompensasjonAnvistBuilder.ny().medBeløp(new BigDecimal(16000))
+            .medAnvistPeriode(IntervallEntitet.fraOgMedTilOgMed(YearMonth.from(fom).atDay(1), YearMonth.from(fom).atEndOfMonth())).build());
+        lk.leggTilAnvistPeriode(LønnskompensasjonAnvist.LønnskompensasjonAnvistBuilder.ny().medBeløp(new BigDecimal(14000))
+            .medAnvistPeriode(IntervallEntitet.fraOgMedTilOgMed(YearMonth.from(tom).atDay(1), YearMonth.from(tom).atEndOfMonth())).build());
+
+        when(repository.hentLønnskompensasjonForIPeriode(any(), any(), any())).thenReturn(Set.of(lk));
+        // Act
+        var mi = samletTjeneste.getLønnskompensasjon(lk.getAktørId(),
+            IntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(17), LocalDate.now()).tilIntervall());
+        assertThat(mi.size()).isEqualTo(2);
+        assertThat(mi.stream().filter(i -> i.getMåned().equals(YearMonth.from(tom))).findAny().orElse(null).getBeløp()).isEqualTo(new BigDecimal(14000));
+    }
+
+}

--- a/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonFilter.java
+++ b/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonFilter.java
@@ -1,0 +1,93 @@
+package no.nav.foreldrepenger.abakus.lonnskomp.domene;
+
+import java.util.Objects;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Converter;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+import no.nav.abakus.iaygrunnlag.kodeverk.IndexKey;
+import no.nav.abakus.iaygrunnlag.kodeverk.InntektskildeType;
+import no.nav.foreldrepenger.abakus.felles.diff.IndexKeyComposer;
+import no.nav.foreldrepenger.abakus.felles.jpa.BaseEntitet;
+import no.nav.foreldrepenger.abakus.typer.Saksnummer;
+
+@Entity(name = "LonnskompFilterEntitet")
+@Table(name = "LONNSKOMP_FILTER")
+public class LønnskompensasjonFilter extends BaseEntitet implements IndexKey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_LONNSKOMP_FILTER")
+    private Long id;
+
+    @Embedded
+    @AttributeOverrides(@AttributeOverride(name = "saksnummer", column = @Column(name = "saksnummer", nullable = false, updatable = false)))
+    private Saksnummer saksnummer;
+
+    @Convert(converter = LocalInntektsKildeKodeverdiConverter.class)
+    @Column(name = "kilde", nullable = false, updatable = false)
+    private InntektskildeType inntektskildeType;
+
+    @Version
+    @Column(name = "versjon", nullable = false)
+    private long versjon;
+
+    public LønnskompensasjonFilter() {
+        // hibernate
+    }
+
+    public LønnskompensasjonFilter(Saksnummer saksnummer, InntektskildeType inntektskildeType) {
+        this.saksnummer = saksnummer;
+        this.inntektskildeType = inntektskildeType;
+    }
+
+    @Override
+    public String getIndexKey() {
+        Object[] keyParts = { this.saksnummer, this.inntektskildeType };
+        return IndexKeyComposer.createKey(keyParts);
+    }
+
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
+    }
+
+    public InntektskildeType getInntektskildeType() {
+        return inntektskildeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LønnskompensasjonFilter that = (LønnskompensasjonFilter) o;
+        return Objects.equals(saksnummer, that.saksnummer) && inntektskildeType == that.inntektskildeType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(saksnummer, inntektskildeType);
+    }
+
+    @Converter(autoApply = true)
+    private static class LocalInntektsKildeKodeverdiConverter implements AttributeConverter<InntektskildeType, String> {
+        @Override
+        public String convertToDatabaseColumn(InntektskildeType attribute) {
+            return attribute == null ? null : attribute.getKode();
+        }
+
+        @Override
+        public InntektskildeType convertToEntityAttribute(String dbData) {
+            return dbData == null ? null : InntektskildeType.fraKode(dbData);
+        }
+    }
+}

--- a/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonVedtak.java
+++ b/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonVedtak.java
@@ -186,6 +186,15 @@ public class LønnskompensasjonVedtak extends BaseEntitet implements IndexKey {
             anvistePerioder.size() == that.anvistePerioder.size() && anvistePerioder.containsAll(that.anvistePerioder);
     }
 
+    public static boolean erLikForBrukerOrg(LønnskompensasjonVedtak v1, LønnskompensasjonVedtak v2) {
+        if (v1 == null && v2 == null) return true;
+        if (v1 == null || v2 == null) return false;
+        return Objects.equals(v1.aktørId, v2.aktørId) &&
+            Objects.equals(v1.orgNummer, v2.orgNummer) &&
+            Objects.equals(v1.periode, v2.periode) &&
+            Objects.equals(v1.beløp, v2.beløp);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(sakId, fnr, orgNummer, periode, beløp, anvistePerioder);

--- a/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/kafka/LonnskompConsumer.java
+++ b/domenetjenester/lonnskomp/src/main/java/no/nav/foreldrepenger/abakus/lonnskomp/kafka/LonnskompConsumer.java
@@ -40,7 +40,7 @@ public class LonnskompConsumer implements AppServiceHandler {
 
         final StreamsBuilder builder = new StreamsBuilder();
 
-        Consumed<String, String> stringStringConsumed = Consumed.with(Topology.AutoOffsetReset.EARLIEST);
+        Consumed<String, String> stringStringConsumed = Consumed.with(Topology.AutoOffsetReset.LATEST);
         builder.stream(this.topic, stringStringConsumed)
             .foreach(lonnskompHendelseHåndterer::handleMessage);
 

--- a/domenetjenester/lonnskomp/src/main/resources/META-INF/pu-default.lonnskomp.orm.xml
+++ b/domenetjenester/lonnskomp/src/main/resources/META-INF/pu-default.lonnskomp.orm.xml
@@ -5,9 +5,11 @@
 
     <sequence-generator name="SEQ_LONNSKOMP_VEDTAK" allocation-size="50" sequence-name="SEQ_LONNSKOMP_VEDTAK" />
     <sequence-generator name="SEQ_LONNSKOMP_ANVIST" allocation-size="50" sequence-name="SEQ_LONNSKOMP_ANVIST" />
+    <sequence-generator name="SEQ_LONNSKOMP_FILTER" allocation-size="50" sequence-name="SEQ_LONNSKOMP_FILTER" />
 
     <!-- InntektArbeidYtelser aggregat og grunnlag -->
     <entity class="no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonVedtak" />
     <entity class="no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonAnvist" />
+    <entity class="no.nav.foreldrepenger.abakus.lonnskomp.domene.LønnskompensasjonFilter" />
 
 </entity-mappings>

--- a/domenetjenester/lonnskomp/src/test/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonRepositoryTest.java
+++ b/domenetjenester/lonnskomp/src/test/java/no/nav/foreldrepenger/abakus/lonnskomp/domene/LønnskompensasjonRepositoryTest.java
@@ -57,11 +57,12 @@ public class LønnskompensasjonRepositoryTest {
             repository.lagre(nyVedtak);
         }
 
-        final var oppdatertVedtattVedtak = repository.hentLønnskompensasjonForIPeriode(AKTØR_ID, LocalDate.now().minusMonths(17), LocalDate.now());
+        final var oppdatertVedtattVedtak = repository.hentLønnskompensasjonForIPeriode(AKTØR_ID, LocalDate.now().minusMonths(17), LocalDate.now())
+            .stream().findFirst().orElse(null);
 
-        assertThat(oppdatertVedtattVedtak).hasSize(1);
-        assertThat(oppdatertVedtattVedtak.get(0).getId()).isNotEqualTo(vedtak.getId());
-        assertThat(oppdatertVedtattVedtak.get(0).getBeløp().getVerdi().longValue()).isEqualTo(10001L);
+        assertThat(oppdatertVedtattVedtak).isNotNull();
+        assertThat(oppdatertVedtattVedtak.getId()).isNotEqualTo(vedtak.getId());
+        assertThat(oppdatertVedtattVedtak.getBeløp().getVerdi().longValue()).isEqualTo(10001L);
     }
 
     @Test
@@ -89,9 +90,10 @@ public class LønnskompensasjonRepositoryTest {
             repository.lagre(nyVedtak);
         }
 
-        final var oppdatertVedtattVedtak = repository.hentLønnskompensasjonForIPeriode(AKTØR_ID, LocalDate.now().minusYears(1), LocalDate.now());
+        final var oppdatertVedtattVedtak = repository.hentLønnskompensasjonForIPeriode(AKTØR_ID, LocalDate.now().minusYears(1), LocalDate.now())
+            .stream().findFirst().orElse(null);
 
-        assertThat(oppdatertVedtattVedtak).hasSize(1);
-        assertThat(oppdatertVedtattVedtak.get(0).getId()).isEqualTo(vedtak.getId());
+        assertThat(oppdatertVedtattVedtak).isNotNull();
+        assertThat(oppdatertVedtattVedtak.getId()).isEqualTo(vedtak.getId());
     }
 }

--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_90__lonnskomp-filter.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_90__lonnskomp-filter.sql
@@ -1,0 +1,23 @@
+create sequence SEQ_LONNSKOMP_FILTER
+    increment by 50
+    START WITH 1000000 NO CYCLE;
+
+create table LONNSKOMP_FILTER
+(
+    ID                   bigint                              not null
+        constraint PK_LONNSKOMP_FILTER
+            primary key,
+    SAKSNUMMER           VARCHAR(19)                         not null,
+    KILDE                VARCHAR(100)                        not null,
+    VERSJON              bigint       default 0              not null,
+    OPPRETTET_AV         VARCHAR(20)  default 'VL'           not null,
+    OPPRETTET_TID        TIMESTAMP(3) default localtimestamp not null,
+    ENDRET_AV            VARCHAR(20),
+    ENDRET_TID           TIMESTAMP(3)
+);
+comment on table LONNSKOMP_FILTER is 'En tabell som styrer innhenting fra Lønnskompensasjon / Koronapenger';
+comment on column LONNSKOMP_FILTER.ID is 'Primærnøkkel';
+comment on column LONNSKOMP_FILTER.SAKSNUMMER is 'Saksnummer fra kobling';
+comment on column LONNSKOMP_FILTER.KILDE is 'Inntektsfilter som skal hente inntekt';
+create index IDX_LONNSKOMP_FILTER_1
+    on LONNSKOMP_FILTER (SAKSNUMMER);


### PR DESCRIPTION
Det er noen hundre tusen vedtak. 
Første antagelse er at det kun er utvalgte av de 5-10000 FP-saker med LK i beregnings eller sammenligningsperiode som trenger LK inn i inntektene - i første omgang sammenligning (der slår man sammen alle inntekter lønn+ytelse++ uansett orgnr)

Neste steg er å laste ned i fpsak og sjekke tilfelle med LK i beregningsperiode der man mangler IM og analysere.

Antas ikke være spesielt aktuelt for OMP ettersom ytelsen er basert på refusjonskrav og IM.