### PR TITLE
TFP-2397 midl løsning for konkurs ag med refusjon

### DIFF
--- a/domenetjenester/lonnskomp/pom.xml
+++ b/domenetjenester/lonnskomp/pom.xml
@@ -41,7 +41,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
+			<artifactId>jakarta.el</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>no.nav.foreldrepenger.abakus</groupId>

--- a/domenetjenester/vedtak/pom.xml
+++ b/domenetjenester/vedtak/pom.xml
@@ -37,7 +37,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
+			<artifactId>jakarta.el</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>no.nav.foreldrepenger.abakus</groupId>

--- a/kodeverk/pom.xml
+++ b/kodeverk/pom.xml
@@ -22,8 +22,8 @@
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
 		</dependency>
 
 		<!-- for å sette opp default ObjectMapper korrekt -->
@@ -47,7 +47,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
+			<artifactId>jakarta.el</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/kontrakt/pom.xml
+++ b/kontrakt/pom.xml
@@ -32,7 +32,7 @@
 		<!-- Test -->
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
+			<artifactId>jakarta.el</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<felles.version>3.0.77</felles.version>
+		<felles.version>3.0.91</felles.version>
 		<prosesstask.version>2.5.15</prosesstask.version>
 
 		<kontrakter.version>5.1_20200117132228_47cdf2f</kontrakter.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -41,11 +41,6 @@
                 <version>7.5.3</version>
             </dependency>
 
-            <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>2.0.1.Final</version>
-            </dependency>
             <!-- Swagger og Swagger-UI -->
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
@@ -337,11 +332,11 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.swagger.core.v3</groupId>

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/app/vedlikehold/EliminerInntektsmeldingRequest.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/app/vedlikehold/EliminerInntektsmeldingRequest.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.abakus.app.vedlikehold;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.abakus.iaygrunnlag.UuidDto;
+
+
+/**
+ * Input request for å bytte en utgått aktørid med en aktiv
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(value = Include.NON_ABSENT, content = Include.NON_EMPTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class EliminerInntektsmeldingRequest {
+
+    @JsonProperty(value = "eksternReferanse", required = true)
+    @Valid
+    private UuidDto eksternReferanse;
+
+    @JsonProperty(value = "journalpostId", required = true)
+    @NotNull
+    @Valid
+    private String journalpostId;
+
+    public EliminerInntektsmeldingRequest() {
+    }
+
+    public UuidDto getEksternReferanse() {
+        return eksternReferanse;
+    }
+
+    public String getJournalpostId() {
+        return journalpostId;
+    }
+}


### PR DESCRIPTION
Midlertidig swagger-løsning for refusjons-tilfelle der arbeidsgiver er konkurs eller omstrukturert slik at de ikke kan sende ny IM på orgnummer med refusjon 0 fom en dato.
Tar inn BehandlingUUID og JournalpostId - Forvaltning / eliminerInntektsmelding

Videre arbeid med 2397 bør se på håndtering av slike tilfelle litt bredere 
* Patche datoen i refusjonOppherer
* Innføre flagg i IM (evt med sjekk mot EREG om virksomhet fortsatt finnes)
* IM-filter-tabell som kan ta vekk en journalpost for alle behandlinger
* Endepunkt som fpsak kan kalle fra Swagger / GUI

Gammel swagger i fpsak virket ikke ettersom GrunnlagRestTjeneste sin PUT bare tar hensyn til overstyringer av arbeidsforhold - ikke endring av IM
