### PR TITLE
fix: bruk partielle indekser framfor funsjonsindekser i postgres for …

### DIFF
--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_95__forbedre-aktiv-indeks-01.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_95__forbedre-aktiv-indeks-01.sql
@@ -1,0 +1,1 @@
+create unique index if not exists uidx_gr_arbeid_inntekt_02 on gr_arbeid_inntekt(kobling_id) where aktiv='J';

--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_96__forbedre-aktiv-indeks-02.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_96__forbedre-aktiv-indeks-02.sql
@@ -1,0 +1,1 @@
+create unique index if not exists uidx_vedtak_ytelse_02 on vedtak_ytelse(saksnummer, aktoer_id, kilde, ytelse_type) where aktiv='J';

--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_97__forbedre-aktiv-indeks-03.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_97__forbedre-aktiv-indeks-03.sql
@@ -1,0 +1,2 @@
+drop index if exists uidx_vedtak_ytelse_01;
+drop index if exists uidx_gr_arbeid_inntekt_01;


### PR DESCRIPTION
…å garantere at det kun er en aktiv versjon

Dvs.  i postgres ikke bruk funksjonell indeks (i oracle er det eneste mulighet)
```
CREATE UNIQUE INDEX IF NOT EXISTS uidx_vedtak_ytelse_01 ON public.vedtak_ytelse USING btree ((
CASE
    WHEN ((aktiv)::text = 'J'::text) THEN (((((((kilde)::text || '-'::text) || (ytelse_type)::text) || '-'::text) || (saksnummer)::text) || '-'::text) || (aktoer_id)::text)
    ELSE NULL::text
END), (
CASE
    WHEN ((aktiv)::text = 'J'::text) THEN aktiv
    ELSE NULL::character varying
END));
```
men heller en partiell indeks
`create unique index if not exists uidx_vedtak_ytelse_02 on vedtak_ytelse(saksnummer, aktoer_id, kilde, ytelse_type) where aktiv='J';`