### PR TITLE
Klarere skille vedtakytelse og grunnlag

### DIFF
--- a/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/VedtattYtelseInnhentingTjenesteTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/foreldrepenger/abakus/registerdata/VedtattYtelseInnhentingTjenesteTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori;
-import no.nav.abakus.iaygrunnlag.kodeverk.TemaUnderkategori;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseAggregatBuilder;
@@ -57,7 +56,6 @@ public class VedtattYtelseInnhentingTjenesteTest {
             .medSaksnummer(new Saksnummer("123"))
             .medKilde(Fagsystem.FPSAK)
             .medYtelseType(YtelseType.ENGANGSTØNAD)
-            .medBehandlingsTema(TemaUnderkategori.ENGANGSSTONAD_FODSEL)
             .leggTil(getYtelseAnvist())
             .build();
         Kobling k = new Kobling();

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelse.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelse.java
@@ -28,7 +28,6 @@ import org.hibernate.annotations.Type;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.IndexKey;
-import no.nav.abakus.iaygrunnlag.kodeverk.TemaUnderkategori;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
@@ -85,11 +84,6 @@ public class VedtakYtelse extends BaseEntitet implements IndexKey {
     @Column(name="kilde", nullable = false)
     private Fagsystem kilde;
 
-    @Convert(converter = TemaUnderkategoriKodeverdiConverter.class)
-    @Column(name="temaUnderkategori", nullable = false)
-    @ChangeTracked
-    private TemaUnderkategori temaUnderkategori = TemaUnderkategori.UDEFINERT;
-
     @Lob
     @Type(type = "org.hibernate.type.TextType")
     @Column(name = "tilleggsopplysninger")
@@ -118,7 +112,6 @@ public class VedtakYtelse extends BaseEntitet implements IndexKey {
         this.status = ytelse.getStatus();
         this.periode = ytelse.getPeriode();
         this.saksnummer = ytelse.getSaksnummer();
-        this.temaUnderkategori = ytelse.getBehandlingsTema();
         this.kilde = ytelse.getKilde();
         this.tilleggsopplysninger = ytelse.getTilleggsopplysninger();
         this.ytelseAnvist = ytelse.getYtelseAnvist()
@@ -148,14 +141,6 @@ public class VedtakYtelse extends BaseEntitet implements IndexKey {
 
     void setYtelseType(YtelseType ytelseType) {
         this.ytelseType = ytelseType;
-    }
-
-    public TemaUnderkategori getBehandlingsTema() {
-        return temaUnderkategori;
-    }
-
-    void setBehandlingsTema(TemaUnderkategori behandlingsTema) {
-        this.temaUnderkategori = behandlingsTema;
     }
 
     public YtelseStatus getStatus() {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseBuilder.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseBuilder.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
-import no.nav.abakus.iaygrunnlag.kodeverk.TemaUnderkategori;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
@@ -83,11 +82,6 @@ public class VedtakYtelseBuilder {
     public VedtakYtelseBuilder leggTil(YtelseAnvistBuilder ytelseAnvist) {
         Objects.requireNonNull(ytelseAnvist, "ytelseAnvist");
         ytelse.leggTilYtelseAnvist(ytelseAnvist.build());
-        return this;
-    }
-
-    public VedtakYtelseBuilder medBehandlingsTema(TemaUnderkategori behandlingsTema) {
-        ytelse.setBehandlingsTema(behandlingsTema);
         return this;
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ConvertToYtelseV1.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ConvertToYtelseV1.java
@@ -1,0 +1,148 @@
+package no.nav.foreldrepenger.abakus.vedtak.extract.v1;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
+import no.nav.abakus.iaygrunnlag.Organisasjon;
+import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
+import no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
+import no.nav.abakus.vedtak.ytelse.Aktør;
+import no.nav.abakus.vedtak.ytelse.Desimaltall;
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
+import no.nav.abakus.vedtak.ytelse.Periode;
+import no.nav.abakus.vedtak.ytelse.Status;
+import no.nav.abakus.vedtak.ytelse.Ytelse;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
+import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.AnvistAndel;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.ArbeidsgiverIdent;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.Inntektklasse;
+import no.nav.foreldrepenger.abakus.typer.Beløp;
+import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
+import no.nav.foreldrepenger.abakus.vedtak.domene.Arbeidsgiver;
+import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelse;
+import no.nav.foreldrepenger.abakus.vedtak.domene.YtelseAnvist;
+
+public final class ConvertToYtelseV1 {
+
+    private ConvertToYtelseV1() {
+    }
+
+    public static Ytelse convert(VedtakYtelse vedtak) {
+        var ytelse = new YtelseV1();
+        var aktør = new Aktør();
+        aktør.setVerdi(vedtak.getAktør().getId());
+        ytelse.setAktør(aktør);
+        ytelse.setVedtattTidspunkt(vedtak.getVedtattTidspunkt());
+        ytelse.setYtelse(mapYtelser(vedtak.getYtelseType()));
+        ytelse.setSaksnummer(vedtak.getSaksnummer().getVerdi());
+        ytelse.setVedtakReferanse(vedtak.getVedtakReferanse().toString());
+        ytelse.setYtelseStatus(mapStatus(vedtak.getStatus()));
+        ytelse.setKildesystem(mapKildesystem(vedtak.getKilde()));
+        ytelse.setTilleggsopplysninger(vedtak.getTilleggsopplysninger());
+        var periode = new Periode();
+        periode.setFom(vedtak.getPeriode().getFomDato());
+        periode.setTom(vedtak.getPeriode().getTomDato());
+        ytelse.setPeriode(periode);
+        var anvist = vedtak.getYtelseAnvist().stream().map(ConvertToYtelseV1::mapLagretAnvist).collect(Collectors.toList());
+        ytelse.setAnvist(anvist);
+        return ytelse;
+    }
+
+
+    private static Anvisning mapLagretAnvist(YtelseAnvist anvist) {
+        var anvisning = new Anvisning();
+        var periode = new Periode();
+        periode.setFom(anvist.getAnvistFom());
+        periode.setTom(anvist.getAnvistTom());
+        anvisning.setPeriode(periode);
+        anvist.getBeløp().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setBeløp);
+        anvist.getDagsats().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setDagsats);
+        anvist.getUtbetalingsgradProsent().map(Stillingsprosent::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setUtbetalingsgrad);
+        anvisning.setAndeler(mapAndeler(anvist));
+
+        return anvisning;
+    }
+
+    private static List<AnvistAndel> mapAndeler(YtelseAnvist anvist) {
+        return anvist.getAndeler().stream().map(a -> new AnvistAndel(
+            a.getArbeidsgiver().map(ConvertToYtelseV1::mapArbeidsgiver).orElse(null),
+            a.getArbeidsgiver().map(ConvertToYtelseV1::mapArbeidsgiverIdent).orElse(null),
+            a.getArbeidsforholdId(),
+            new Desimaltall(a.getDagsats().getVerdi()),
+            a.getUtbetalingsgradProsent() == null ? null : new Desimaltall(a.getUtbetalingsgradProsent().getVerdi()),
+            a.getRefusjonsgradProsent() == null ? null : new Desimaltall(a.getRefusjonsgradProsent().getVerdi()),
+            fraInntektskategori(a.getInntektskategori())
+        )).collect(Collectors.toList());
+    }
+
+
+    private static no.nav.abakus.iaygrunnlag.Aktør mapArbeidsgiver(Arbeidsgiver arbeidsgiver) {
+        if (arbeidsgiver == null) {
+            return null;
+        }
+        return arbeidsgiver.getOrgnr() != null ?
+            new Organisasjon(arbeidsgiver.getIdentifikator()) :
+            new AktørIdPersonident(arbeidsgiver.getIdentifikator());
+    }
+
+    private static ArbeidsgiverIdent mapArbeidsgiverIdent(Arbeidsgiver arbeidsgiver) {
+        if (arbeidsgiver == null) {
+            return null;
+        }
+        return new ArbeidsgiverIdent(arbeidsgiver.getIdentifikator());
+    }
+
+    public static Kildesystem mapKildesystem(Fagsystem fagsystem) {
+        return switch (fagsystem) {
+            case FPSAK -> Kildesystem.FPSAK;
+            case K9SAK -> Kildesystem.K9SAK;
+            default -> null;
+        };
+    }
+
+    public static Status mapStatus(YtelseStatus ytelseStatus) {
+        return switch (ytelseStatus) {
+            case OPPRETTET, UNDER_BEHANDLING -> Status.UNDER_BEHANDLING;
+            case LØPENDE -> Status.LØPENDE;
+            case AVSLUTTET -> Status.AVSLUTTET;
+            default -> Status.UKJENT;
+        };
+    }
+
+    public static Ytelser mapYtelser(YtelseType kodeverk) {
+        return switch (kodeverk) {
+            case PLEIEPENGER_SYKT_BARN -> Ytelser.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> Ytelser.PLEIEPENGER_NÆRSTÅENDE;
+            case OMSORGSPENGER -> Ytelser.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> Ytelser.OPPLÆRINGSPENGER;
+
+            case ENGANGSTØNAD -> Ytelser.ENGANGSTØNAD;
+            case FORELDREPENGER -> Ytelser.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelser.SVANGERSKAPSPENGER;
+
+            case FRISINN -> Ytelser.FRISINN;
+            default -> null;
+        };
+    }
+
+    public static Inntektklasse fraInntektskategori(Inntektskategori inntektskategori) {
+        return switch (inntektskategori) {
+            case ARBEIDSTAKER -> Inntektklasse.ARBEIDSTAKER;
+            case ARBEIDSTAKER_UTEN_FERIEPENGER -> Inntektklasse.ARBEIDSTAKER_UTEN_FERIEPENGER;
+            case FRILANSER -> Inntektklasse.FRILANSER;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> Inntektklasse.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case DAGPENGER -> Inntektklasse.DAGPENGER;
+            case ARBEIDSAVKLARINGSPENGER -> Inntektklasse.ARBEIDSAVKLARINGSPENGER;
+            case SJØMANN -> Inntektklasse.MARITIM;
+            case DAGMAMMA -> Inntektklasse.DAGMAMMA;
+            case JORDBRUKER -> Inntektklasse.JORDBRUKER;
+            case FISKER -> Inntektklasse.FISKER;
+            default -> Inntektklasse.INGEN;
+        };
+    }
+}

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import no.nav.abakus.iaygrunnlag.Aktør;
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
@@ -81,7 +80,7 @@ public class ExtractFromYtelseV1 implements ExtractFromYtelse<YtelseV1> {
             .medDagsats(andel.getDagsats().getVerdi())
             .medUtbetalingsgrad(andel.getUtbetalingsgrad().getVerdi())
             .medRefusjonsgrad(andel.getRefusjonsgrad().getVerdi())
-            .medArbeidsgiver(mapArbeidsgiver(andel.getArbeidsgiver()))
+            .medArbeidsgiver(mapArbeidsgiver(andel))
             .medArbeidsforholdId(andel.getArbeidsforholdId());
     }
 
@@ -104,9 +103,14 @@ public class ExtractFromYtelseV1 implements ExtractFromYtelse<YtelseV1> {
         };
     }
 
-    private Arbeidsgiver mapArbeidsgiver(Aktør arbeidsgiver) {
-        if (arbeidsgiver == null) {
+    private Arbeidsgiver mapArbeidsgiver(AnvistAndel andel) {
+        var arbeidsgiver = andel.getArbeidsgiver();
+        var arbeidsgiverIdent = andel.getArbeidsgiverIdent();
+        if (arbeidsgiver == null && arbeidsgiverIdent == null) {
             return null;
+        }
+        if (arbeidsgiverIdent != null) {
+            return arbeidsgiverIdent.erOrganisasjon() ? Arbeidsgiver.virksomhet(arbeidsgiverIdent.ident()) : Arbeidsgiver.person(arbeidsgiverIdent.ident());
         }
         return arbeidsgiver.getErOrganisasjon() ? Arbeidsgiver.virksomhet(arbeidsgiver.getIdent()) : Arbeidsgiver.person(arbeidsgiver.getIdent());
     }

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTaskTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/LagreVedtakTaskTest.java
@@ -127,6 +127,9 @@ public class LagreVedtakTaskTest {
                     "identType" : "ORGNUMMER",
                     "ident" : "972674818"
                   },
+                  "arbeidsgiverIdent" : {
+                    "ident" : "972674818"
+                  },
                   "arbeidsforholdId" : "1",
                   "dagsats" : {
                     "verdi" : 1846.00
@@ -154,6 +157,9 @@ public class LagreVedtakTaskTest {
                 "andeler" : [ {
                   "arbeidsgiver" : {
                     "identType" : "ORGNUMMER",
+                    "ident" : "972674818"
+                  },
+                  "arbeidsgiverIdent" : {
                     "ident" : "972674818"
                   },
                   "arbeidsforholdId" : "1",

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1Test.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/abakus/vedtak/extract/v1/ExtractFromYtelseV1Test.java
@@ -22,6 +22,7 @@ import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.AnvistAndel;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.ArbeidsgiverIdent;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Inntektklasse;
 import no.nav.foreldrepenger.abakus.dbstoette.JpaExtension;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseBuilder;
@@ -56,7 +57,7 @@ public class ExtractFromYtelseV1Test {
 
         Anvisning anvisning = new Anvisning();
         anvisning.setPeriode(periode);
-        anvisning.setAndeler(List.of(new AnvistAndel(new Organisasjon("999999999"), 1236, 100, 100, Inntektklasse.ARBEIDSTAKER, "ehuif2897")));
+        anvisning.setAndeler(List.of(new AnvistAndel(new Organisasjon("999999999"), new ArbeidsgiverIdent("999999999"), 1236, 100, 100, Inntektklasse.ARBEIDSTAKER, "ehuif2897")));
         ytelseV1.setAnvist(List.of(anvisning));
 
         VedtakYtelseBuilder builder = extractor.extractFrom(ytelseV1);
@@ -96,7 +97,7 @@ public class ExtractFromYtelseV1Test {
 
         Anvisning anvisning = new Anvisning();
         anvisning.setPeriode(periode);
-        anvisning.setAndeler(List.of(new AnvistAndel(new Organisasjon("999999999"), 1236, 100, 100, Inntektklasse.ARBEIDSTAKER, "ehuif2897")));
+        anvisning.setAndeler(List.of(new AnvistAndel(new Organisasjon("999999999"),  new ArbeidsgiverIdent("999999999"), 1236, 100, 100, Inntektklasse.ARBEIDSTAKER, "ehuif2897")));
         ytelseV1.setAnvist(List.of(anvisning));
 
         VedtakYtelseBuilder builder = extractor.extractFrom(ytelseV1);

--- a/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/Aktør.java
+++ b/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/Aktør.java
@@ -23,8 +23,12 @@ public class Aktør {
         this.verdi = verdi;
     }
 
+    public boolean erAktørId() {
+        return verdi.length() == 13;
+    }
+
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[verdi=" + verdi + "]";
+        return getClass().getSimpleName() + "[verdi=MASKERT]";
     }
 }

--- a/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/request/VedtakForPeriodeRequest.java
+++ b/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/request/VedtakForPeriodeRequest.java
@@ -1,0 +1,66 @@
+package no.nav.abakus.vedtak.ytelse.request;
+
+import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.abakus.vedtak.ytelse.Aktør;
+import no.nav.abakus.vedtak.ytelse.Periode;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_EMPTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class VedtakForPeriodeRequest {
+
+    public static final Set<Ytelser> ALLE_YTELSER = Set.of(Ytelser.FORELDREPENGER, Ytelser.SVANGERSKAPSPENGER,
+        Ytelser.PLEIEPENGER_SYKT_BARN, Ytelser.PLEIEPENGER_NÆRSTÅENDE, Ytelser.OPPLÆRINGSPENGER, Ytelser.OMSORGSPENGER,
+        Ytelser.FRISINN);
+
+    @JsonProperty(value = "ident", required = true)
+    @NotNull
+    @Valid
+    private Aktør ident;
+
+    @JsonProperty(value = "periode", required = true)
+    @NotNull
+    @Valid
+    private Periode periode;
+
+    @JsonProperty(value = "ytelser")
+    private Set<Ytelser> ytelser = ALLE_YTELSER;
+
+    private VedtakForPeriodeRequest() {
+    }
+
+    public VedtakForPeriodeRequest(Aktør ident, Periode periode) {
+        this.ident = Objects.requireNonNull(ident);
+        this.periode = Objects.requireNonNull(periode);
+    }
+
+    public VedtakForPeriodeRequest(Aktør ident, Periode periode, Set<Ytelser> ytelser) {
+        this.ident = Objects.requireNonNull(ident);
+        this.periode = Objects.requireNonNull(periode);
+        this.ytelser = Objects.requireNonNull(ytelser);
+    }
+
+    public Aktør getIdent() {
+        return ident;
+    }
+
+    public Periode getPeriode() {
+        return periode;
+    }
+
+    public Set<Ytelser> getYtelser() {
+        return ytelser;
+    }
+}

--- a/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/v1/anvisning/AnvistAndel.java
+++ b/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/v1/anvisning/AnvistAndel.java
@@ -27,6 +27,10 @@ public class AnvistAndel {
     @Valid
     private Aktør arbeidsgiver;
 
+    @JsonProperty(value = "arbeidsgiverIdent")
+    @Valid
+    private ArbeidsgiverIdent arbeidsgiverIdent;
+
     @JsonProperty(value = "arbeidsforholdId")
     @Valid
     private String arbeidsforholdId;
@@ -48,16 +52,32 @@ public class AnvistAndel {
     protected AnvistAndel() {
     }
 
+    @Deprecated(forRemoval = true)
     public AnvistAndel(Aktør arbeidsgiver, int beløp, int utbetalingsgrad, int refusjonsgrad, Inntektklasse inntektklasse, String arbeidsforholdId) {
-        this(arbeidsgiver,
-            arbeidsforholdId, new Desimaltall(BigDecimal.valueOf(beløp)),
+        this(arbeidsgiver,Optional.ofNullable(arbeidsgiver).map(Aktør::getIdent).map(ArbeidsgiverIdent::new).orElse(null), arbeidsforholdId,
+            new Desimaltall(BigDecimal.valueOf(beløp)),
             new Desimaltall(BigDecimal.valueOf(utbetalingsgrad)),
             new Desimaltall(BigDecimal.valueOf(refusjonsgrad)),
             inntektklasse);
     }
 
+    @Deprecated(forRemoval = true)
     public AnvistAndel(Aktør arbeidsgiver, String arbeidsforholdId, Desimaltall beløp, Desimaltall utbetalingsgrad, Desimaltall refusjonsgrad, Inntektklasse inntektklasse) {
-        this.arbeidsgiver = arbeidsgiver;
+        this(arbeidsgiver, Optional.ofNullable(arbeidsgiver).map(Aktør::getIdent).map(ArbeidsgiverIdent::new).orElse(null),
+            arbeidsforholdId, beløp, utbetalingsgrad, refusjonsgrad, inntektklasse);
+    }
+
+    public AnvistAndel(ArbeidsgiverIdent arbeidsgiverIdent, int beløp, int utbetalingsgrad, int refusjonsgrad, Inntektklasse inntektklasse, String arbeidsforholdId) {
+        this(arbeidsgiverIdent, arbeidsforholdId,
+            new Desimaltall(BigDecimal.valueOf(beløp)),
+            new Desimaltall(BigDecimal.valueOf(utbetalingsgrad)),
+            new Desimaltall(BigDecimal.valueOf(refusjonsgrad)),
+            inntektklasse);
+    }
+
+    public AnvistAndel(ArbeidsgiverIdent arbeidsgiverIdent, String arbeidsforholdId, Desimaltall beløp, Desimaltall utbetalingsgrad, Desimaltall refusjonsgrad, Inntektklasse inntektklasse) {
+        this.arbeidsgiver = null;
+        this.arbeidsgiverIdent = arbeidsgiverIdent;
         this.arbeidsforholdId = arbeidsforholdId;
         this.dagsats = beløp;
         this.utbetalingsgrad = utbetalingsgrad;
@@ -65,8 +85,33 @@ public class AnvistAndel {
         this.inntektklasse = inntektklasse;
     }
 
+    @Deprecated(forRemoval = true)
+    public AnvistAndel(Aktør arbeidsgiver, ArbeidsgiverIdent arbeidsgiverIdent, int beløp, int utbetalingsgrad, int refusjonsgrad, Inntektklasse inntektklasse, String arbeidsforholdId) {
+        this(arbeidsgiver, arbeidsgiverIdent, arbeidsforholdId,
+            new Desimaltall(BigDecimal.valueOf(beløp)),
+            new Desimaltall(BigDecimal.valueOf(utbetalingsgrad)),
+            new Desimaltall(BigDecimal.valueOf(refusjonsgrad)),
+            inntektklasse);
+    }
+
+    @Deprecated(forRemoval = true)
+    public AnvistAndel(Aktør arbeidsgiver, ArbeidsgiverIdent arbeidsgiverIdent, String arbeidsforholdId, Desimaltall beløp, Desimaltall utbetalingsgrad, Desimaltall refusjonsgrad, Inntektklasse inntektklasse) {
+        this.arbeidsgiver = arbeidsgiver;
+        this.arbeidsgiverIdent = arbeidsgiverIdent;
+        this.arbeidsforholdId = arbeidsforholdId;
+        this.dagsats = beløp;
+        this.utbetalingsgrad = utbetalingsgrad;
+        this.refusjonsgrad = refusjonsgrad;
+        this.inntektklasse = inntektklasse;
+    }
+
+    @Deprecated(forRemoval = true)
     public Aktør getArbeidsgiver() {
         return arbeidsgiver;
+    }
+
+    public ArbeidsgiverIdent getArbeidsgiverIdent() {
+        return arbeidsgiverIdent;
     }
 
     public String getArbeidsforholdId() {

--- a/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/v1/anvisning/ArbeidsgiverIdent.java
+++ b/kontrakt/src/main/java/no/nav/abakus/vedtak/ytelse/v1/anvisning/ArbeidsgiverIdent.java
@@ -1,0 +1,19 @@
+package no.nav.abakus.vedtak.ytelse.v1.anvisning;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// Orgnr / aktørid
+public record ArbeidsgiverIdent(@NotNull @JsonProperty("ident") @Pattern(regexp = "\\d{9}|\\d{13}") String ident) {
+
+    public boolean erOrganisasjon() {
+        return ident().length() == 9;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[verdi=MASKERT]";
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/app/rest/ekstern/EksternDelingAvYtelserRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/app/rest/ekstern/EksternDelingAvYtelserRestTjeneste.java
@@ -26,23 +26,19 @@ import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
 import no.nav.abakus.iaygrunnlag.Organisasjon;
-import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
-import no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori;
-import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.HentBrukersK9YtelserIPeriodeRequest;
 import no.nav.abakus.iaygrunnlag.request.HentBrukersYtelserIPeriodeRequest;
 import no.nav.abakus.vedtak.ytelse.Aktør;
 import no.nav.abakus.vedtak.ytelse.Desimaltall;
-import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Periode;
-import no.nav.abakus.vedtak.ytelse.Status;
 import no.nav.abakus.vedtak.ytelse.Ytelse;
 import no.nav.abakus.vedtak.ytelse.Ytelser;
+import no.nav.abakus.vedtak.ytelse.request.VedtakForPeriodeRequest;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.AnvistAndel;
-import no.nav.abakus.vedtak.ytelse.v1.anvisning.Inntektklasse;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.ArbeidsgiverIdent;
 import no.nav.foreldrepenger.abakus.aktor.AktørTjeneste;
 import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.registerdata.infotrygd.InfotrygdgrunnlagYtelseMapper;
@@ -51,10 +47,8 @@ import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.PersonIdent;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-import no.nav.foreldrepenger.abakus.vedtak.domene.Arbeidsgiver;
-import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelse;
 import no.nav.foreldrepenger.abakus.vedtak.domene.VedtakYtelseRepository;
-import no.nav.foreldrepenger.abakus.vedtak.domene.YtelseAnvist;
+import no.nav.foreldrepenger.abakus.vedtak.extract.v1.ConvertToYtelseV1;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
@@ -84,7 +78,6 @@ public class EksternDelingAvYtelserRestTjeneste {
 
     private VedtakYtelseRepository ytelseRepository;
     private AktørTjeneste aktørTjeneste;
-
     private InnhentingInfotrygdTjeneste innhentingInfotrygdTjeneste;
 
     public EksternDelingAvYtelserRestTjeneste() {
@@ -97,37 +90,46 @@ public class EksternDelingAvYtelserRestTjeneste {
         this.innhentingInfotrygdTjeneste = innhentingInfotrygdTjeneste;
     }
 
-    private static no.nav.abakus.iaygrunnlag.Aktør mapArbeidsgiver(Arbeidsgiver arbeidsgiver) {
-        if (arbeidsgiver == null) {
-            return null;
+    @POST
+    @Path("/hent-ytelse-vedtak")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Henter alle vedtak for en gitt person, evt med periode etter en fom", tags = "ytelse")
+    @BeskyttetRessurs(actionType = ActionType.READ, resource = VEDTAK)
+    @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
+    public List<Ytelse> hentVedtakYtelse(@NotNull @TilpassetAbacAttributt(supplierClass = EksternDelingAvYtelserRestTjeneste.VedtakForPeriodeRequestAbacDataSupplier.class) @Valid VedtakForPeriodeRequest request) {
+
+        if (request.getYtelser().isEmpty()) {
+            return List.of();
         }
-        return arbeidsgiver.getOrgnr() != null ?
-            new Organisasjon(arbeidsgiver.getIdentifikator()) :
-            new AktørIdPersonident(arbeidsgiver.getIdentifikator());
-    }
-    private static no.nav.abakus.iaygrunnlag.Aktør mapArbeidsgiver(no.nav.foreldrepenger.abakus.domene.iay.Arbeidsgiver arbeidsgiver) {
-        if (arbeidsgiver == null) {
-            return null;
+
+        Set<AktørId> aktørIder = utledAktørIdFraRequest(request.getIdent(), utledTemaFraYtelser(request.getYtelser()));
+        var periode = IntervallEntitet.fraOgMedTilOgMed(request.getPeriode().getFom(), request.getPeriode().getTom());
+        var ytelser = new ArrayList<Ytelse>();
+        for (AktørId aktørId : aktørIder) {
+            ytelser.addAll(ytelseRepository.hentYtelserForIPeriode(aktørId, periode)
+                .stream()
+                .filter(it -> request.getYtelser().contains(ConvertToYtelseV1.mapYtelser(it.getYtelseType())))
+                .map(ConvertToYtelseV1::convert)
+                .toList());
         }
-        return arbeidsgiver.getOrgnr() != null ?
-            new Organisasjon(arbeidsgiver.getIdentifikator()) :
-            new AktørIdPersonident(arbeidsgiver.getIdentifikator());
+
+        return ytelser;
     }
 
-    private static Inntektklasse fraInntektskategori(Inntektskategori inntektskategori) {
-        return switch (inntektskategori) {
-            case ARBEIDSTAKER -> Inntektklasse.ARBEIDSTAKER;
-            case ARBEIDSTAKER_UTEN_FERIEPENGER -> Inntektklasse.ARBEIDSTAKER_UTEN_FERIEPENGER;
-            case FRILANSER -> Inntektklasse.FRILANSER;
-            case SELVSTENDIG_NÆRINGSDRIVENDE -> Inntektklasse.SELVSTENDIG_NÆRINGSDRIVENDE;
-            case DAGPENGER -> Inntektklasse.DAGPENGER;
-            case ARBEIDSAVKLARINGSPENGER -> Inntektklasse.ARBEIDSAVKLARINGSPENGER;
-            case SJØMANN -> Inntektklasse.MARITIM;
-            case DAGMAMMA -> Inntektklasse.DAGMAMMA;
-            case JORDBRUKER -> Inntektklasse.JORDBRUKER;
-            case FISKER -> Inntektklasse.FISKER;
-            default -> Inntektklasse.INGEN;
-        };
+    private Set<AktørId> utledAktørIdFraRequest(Aktør aktør, YtelseType tema) {
+        if (aktør.erAktørId()) {
+            return Set.of(new AktørId(aktør.getVerdi()));
+        }
+        return aktørTjeneste.hentAktørIderForIdent(new PersonIdent(aktør.getVerdi()), tema);
+    }
+
+    private YtelseType utledTemaFraYtelser(Set<Ytelser> request) {
+        if (request.contains(Ytelser.FORELDREPENGER)) {
+            return YtelseType.FORELDREPENGER;
+        }
+
+        return YtelseType.OMSORGSPENGER;
     }
 
     @POST
@@ -147,82 +149,6 @@ public class EksternDelingAvYtelserRestTjeneste {
         return hentUtYtelser(request, etterspurteYtelser, false);
     }
 
-    private List<Ytelse> hentUtYtelser(HentBrukersYtelserIPeriodeRequest request, Set<YtelseType> etterspurteYtelser, boolean hentHistoriske) {
-        if (etterspurteYtelser.isEmpty()) {
-            return List.of();
-        }
-
-        var ytelser = new ArrayList<Ytelse>();
-        var fnr = new PersonIdent(request.getPersonident().getIdent());
-        var aktørIder = aktørTjeneste.hentAktørIderForIdent(fnr, utledTema(etterspurteYtelser));
-
-        LocalDate fom = request.getPeriode().getFom();
-        LocalDate tom = request.getPeriode().getTom();
-
-        var periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
-
-        if (hentHistoriske) {
-            var aktørId = aktørTjeneste.hentAktørForIdent(fnr, utledTema(etterspurteYtelser)).orElseThrow();
-            var infotrygdYtelser = innhentingInfotrygdTjeneste.getInfotrygdYtelser(fnr, periode);
-            ytelser.addAll(infotrygdYtelser.stream()
-                .map(InfotrygdgrunnlagYtelseMapper::oversettInfotrygdYtelseGrunnlagTilYtelse)
-                .filter(it -> etterspurteYtelser.contains(it.getRelatertYtelseType()))
-                .map(it -> ytelseTilYtelse(aktørId, it))
-                .toList());
-        }
-        for (AktørId aktørId : aktørIder) {
-            ytelser.addAll(ytelseRepository.hentYtelserForIPeriode(aktørId, periode)
-                .stream()
-                .filter(it -> etterspurteYtelser.contains(it.getYtelseType()))
-                .map(this::mapLagretVedtakTilYtelse)
-                .toList());
-        }
-
-        return ytelser;
-    }
-
-    private YtelseV1 ytelseTilYtelse(AktørId aktørId, no.nav.foreldrepenger.abakus.domene.iay.Ytelse vedtak) {
-        var ytelse = new YtelseV1();
-        var aktør = new Aktør();
-        aktør.setVerdi(aktørId.getId());
-        ytelse.setAktør(aktør);
-        ytelse.setVedtattTidspunkt(vedtak.getVedtattTidspunkt());
-        ytelse.setYtelse(mapYtelser(vedtak.getRelatertYtelseType()));
-        ytelse.setSaksnummer(vedtak.getSaksreferanse().getVerdi());
-        ytelse.setYtelseStatus(mapStatus(vedtak.getStatus()));
-        ytelse.setKildesystem(mapKildesystem(vedtak.getKilde()));
-        var periode = new Periode();
-        periode.setFom(vedtak.getPeriode().getFomDato());
-        periode.setTom(vedtak.getPeriode().getTomDato());
-        ytelse.setPeriode(periode);
-        var anvist = vedtak.getYtelseAnvist().stream().map(this::mapLagretInfotrygdAnvist).collect(Collectors.toList());
-        ytelse.setAnvist(anvist);
-        return ytelse;
-    }
-
-    private Anvisning mapLagretInfotrygdAnvist(no.nav.foreldrepenger.abakus.domene.iay.YtelseAnvist anvist) {
-        var anvisning = new Anvisning();
-        var periode = new Periode();
-        periode.setFom(anvist.getAnvistFOM());
-        periode.setTom(anvist.getAnvistTOM());
-        anvisning.setPeriode(periode);
-        anvist.getBeløp().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setBeløp);
-        anvist.getDagsats().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setDagsats);
-        anvist.getUtbetalingsgradProsent().map(Stillingsprosent::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setUtbetalingsgrad);
-        anvisning.setAndeler(mapInfotrygdAndeler(anvist));
-
-        return anvisning;
-    }
-
-    private List<AnvistAndel> mapInfotrygdAndeler(no.nav.foreldrepenger.abakus.domene.iay.YtelseAnvist anvist) {
-        return anvist.getYtelseAnvistAndeler().stream().map(a -> new AnvistAndel(
-            a.getArbeidsgiver().map(EksternDelingAvYtelserRestTjeneste::mapArbeidsgiver).orElse(null), a.getArbeidsforholdRef().getReferanse(),
-            new Desimaltall(a.getDagsats().getVerdi()),
-            a.getUtbetalingsgradProsent() == null ? null : new Desimaltall(a.getUtbetalingsgradProsent().getVerdi()),
-            a.getRefusjonsgradProsent() == null ? null : new Desimaltall(a.getRefusjonsgradProsent().getVerdi()),
-            fraInntektskategori(a.getInntektskategori())
-        )).collect(Collectors.toList());
-    }
 
     @POST
     @Path("/hent-vedtatte/for-ident/k9")
@@ -253,6 +179,101 @@ public class EksternDelingAvYtelserRestTjeneste {
         return hentUtYtelser(request, etterspurteYtelser, true);
     }
 
+    private List<Ytelse> hentUtYtelser(HentBrukersYtelserIPeriodeRequest request, Set<YtelseType> etterspurteYtelser, boolean hentHistoriske) {
+        if (etterspurteYtelser.isEmpty()) {
+            return List.of();
+        }
+
+        var ytelser = new ArrayList<Ytelse>();
+        var fnr = new PersonIdent(request.getPersonident().getIdent());
+        var aktørIder = aktørTjeneste.hentAktørIderForIdent(fnr, utledTema(etterspurteYtelser));
+
+        LocalDate fom = request.getPeriode().getFom();
+        LocalDate tom = request.getPeriode().getTom();
+
+        var periode = IntervallEntitet.fraOgMedTilOgMed(fom, tom);
+
+        if (hentHistoriske) {
+            var aktørId = aktørTjeneste.hentAktørForIdent(fnr, utledTema(etterspurteYtelser)).orElseThrow();
+            var infotrygdYtelser = innhentingInfotrygdTjeneste.getInfotrygdYtelser(fnr, periode);
+            ytelser.addAll(infotrygdYtelser.stream()
+                .map(InfotrygdgrunnlagYtelseMapper::oversettInfotrygdYtelseGrunnlagTilYtelse)
+                .filter(it -> etterspurteYtelser.contains(it.getRelatertYtelseType()))
+                .map(it -> ytelseTilYtelse(aktørId, it))
+                .toList());
+        }
+        for (AktørId aktørId : aktørIder) {
+            ytelser.addAll(ytelseRepository.hentYtelserForIPeriode(aktørId, periode)
+                .stream()
+                .filter(it -> etterspurteYtelser.contains(it.getYtelseType()))
+                .map(ConvertToYtelseV1::convert)
+                .toList());
+        }
+
+        return ytelser;
+    }
+
+    private YtelseV1 ytelseTilYtelse(AktørId aktørId, no.nav.foreldrepenger.abakus.domene.iay.Ytelse vedtak) {
+        var ytelse = new YtelseV1();
+        var aktør = new Aktør();
+        aktør.setVerdi(aktørId.getId());
+        ytelse.setAktør(aktør);
+        ytelse.setVedtattTidspunkt(vedtak.getVedtattTidspunkt());
+        ytelse.setYtelse(ConvertToYtelseV1.mapYtelser(vedtak.getRelatertYtelseType()));
+        ytelse.setSaksnummer(vedtak.getSaksreferanse().getVerdi());
+        ytelse.setYtelseStatus(ConvertToYtelseV1.mapStatus(vedtak.getStatus()));
+        ytelse.setKildesystem(ConvertToYtelseV1.mapKildesystem(vedtak.getKilde()));
+        var periode = new Periode();
+        periode.setFom(vedtak.getPeriode().getFomDato());
+        periode.setTom(vedtak.getPeriode().getTomDato());
+        ytelse.setPeriode(periode);
+        var anvist = vedtak.getYtelseAnvist().stream().map(this::mapLagretInfotrygdAnvist).collect(Collectors.toList());
+        ytelse.setAnvist(anvist);
+        return ytelse;
+    }
+
+    private Anvisning mapLagretInfotrygdAnvist(no.nav.foreldrepenger.abakus.domene.iay.YtelseAnvist anvist) {
+        var anvisning = new Anvisning();
+        var periode = new Periode();
+        periode.setFom(anvist.getAnvistFOM());
+        periode.setTom(anvist.getAnvistTOM());
+        anvisning.setPeriode(periode);
+        anvist.getBeløp().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setBeløp);
+        anvist.getDagsats().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setDagsats);
+        anvist.getUtbetalingsgradProsent().map(Stillingsprosent::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setUtbetalingsgrad);
+        anvisning.setAndeler(mapInfotrygdAndeler(anvist));
+
+        return anvisning;
+    }
+
+    private List<AnvistAndel> mapInfotrygdAndeler(no.nav.foreldrepenger.abakus.domene.iay.YtelseAnvist anvist) {
+        return anvist.getYtelseAnvistAndeler().stream().map(a -> new AnvistAndel(
+            a.getArbeidsgiver().map(EksternDelingAvYtelserRestTjeneste::mapArbeidsgiver).orElse(null),
+            a.getArbeidsgiver().map(EksternDelingAvYtelserRestTjeneste::mapArbeidsgiverIdent).orElse(null),
+            a.getArbeidsforholdRef().getReferanse(),
+            new Desimaltall(a.getDagsats().getVerdi()),
+            a.getUtbetalingsgradProsent() == null ? null : new Desimaltall(a.getUtbetalingsgradProsent().getVerdi()),
+            a.getRefusjonsgradProsent() == null ? null : new Desimaltall(a.getRefusjonsgradProsent().getVerdi()),
+            ConvertToYtelseV1.fraInntektskategori(a.getInntektskategori())
+        )).collect(Collectors.toList());
+    }
+
+    private static no.nav.abakus.iaygrunnlag.Aktør mapArbeidsgiver(no.nav.foreldrepenger.abakus.domene.iay.Arbeidsgiver arbeidsgiver) {
+        if (arbeidsgiver == null) {
+            return null;
+        }
+        return arbeidsgiver.getOrgnr() != null ?
+            new Organisasjon(arbeidsgiver.getIdentifikator()) :
+            new AktørIdPersonident(arbeidsgiver.getIdentifikator());
+    }
+
+    private static ArbeidsgiverIdent mapArbeidsgiverIdent(no.nav.foreldrepenger.abakus.domene.iay.Arbeidsgiver arbeidsgiver) {
+        if (arbeidsgiver == null) {
+            return null;
+        }
+        return new ArbeidsgiverIdent(arbeidsgiver.getIdentifikator());
+    }
+
     private YtelseType utledTema(Set<YtelseType> request) {
         if (request.contains(YtelseType.FORELDREPENGER)) {
             return YtelseType.FORELDREPENGER;
@@ -261,83 +282,6 @@ public class EksternDelingAvYtelserRestTjeneste {
         return YtelseType.OMSORGSPENGER;
     }
 
-    private Ytelse mapLagretVedtakTilYtelse(VedtakYtelse vedtak) {
-        var ytelse = new YtelseV1();
-        var aktør = new Aktør();
-        aktør.setVerdi(vedtak.getAktør().getId());
-        ytelse.setAktør(aktør);
-        ytelse.setVedtattTidspunkt(vedtak.getVedtattTidspunkt());
-        ytelse.setYtelse(mapYtelser(vedtak.getYtelseType()));
-        ytelse.setSaksnummer(vedtak.getSaksnummer().getVerdi());
-        ytelse.setVedtakReferanse(vedtak.getVedtakReferanse().toString());
-        ytelse.setYtelseStatus(mapStatus(vedtak.getStatus()));
-        ytelse.setKildesystem(mapKildesystem(vedtak.getKilde()));
-        ytelse.setTilleggsopplysninger(vedtak.getTilleggsopplysninger());
-        var periode = new Periode();
-        periode.setFom(vedtak.getPeriode().getFomDato());
-        periode.setTom(vedtak.getPeriode().getTomDato());
-        ytelse.setPeriode(periode);
-        var anvist = vedtak.getYtelseAnvist().stream().map(this::mapLagretAnvist).collect(Collectors.toList());
-        ytelse.setAnvist(anvist);
-        return ytelse;
-    }
-
-    private Anvisning mapLagretAnvist(YtelseAnvist anvist) {
-        var anvisning = new Anvisning();
-        var periode = new Periode();
-        periode.setFom(anvist.getAnvistFom());
-        periode.setTom(anvist.getAnvistTom());
-        anvisning.setPeriode(periode);
-        anvist.getBeløp().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setBeløp);
-        anvist.getDagsats().map(Beløp::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setDagsats);
-        anvist.getUtbetalingsgradProsent().map(Stillingsprosent::getVerdi).map(Desimaltall::new).ifPresent(anvisning::setUtbetalingsgrad);
-        anvisning.setAndeler(mapAndeler(anvist));
-
-        return anvisning;
-    }
-
-    private List<AnvistAndel> mapAndeler(YtelseAnvist anvist) {
-        return anvist.getAndeler().stream().map(a -> new AnvistAndel(
-            a.getArbeidsgiver().map(EksternDelingAvYtelserRestTjeneste::mapArbeidsgiver).orElse(null),
-            a.getArbeidsforholdId(),
-            new Desimaltall(a.getDagsats().getVerdi()),
-            a.getUtbetalingsgradProsent() == null ? null : new Desimaltall(a.getUtbetalingsgradProsent().getVerdi()),
-            a.getRefusjonsgradProsent() == null ? null : new Desimaltall(a.getRefusjonsgradProsent().getVerdi()),
-            fraInntektskategori(a.getInntektskategori())
-        )).collect(Collectors.toList());
-    }
-
-    private Kildesystem mapKildesystem(Fagsystem fagsystem) {
-        return switch (fagsystem) {
-            case FPSAK -> Kildesystem.FPSAK;
-            case K9SAK -> Kildesystem.K9SAK;
-            default -> null;
-        };
-    }
-
-    private Status mapStatus(YtelseStatus ytelseStatus) {
-        return switch (ytelseStatus) {
-            case OPPRETTET, UNDER_BEHANDLING -> Status.UNDER_BEHANDLING;
-            case LØPENDE -> Status.LØPENDE;
-            case AVSLUTTET -> Status.AVSLUTTET;
-            default -> Status.UKJENT;
-        };
-    }
-
-    private Ytelser mapYtelser(YtelseType kodeverk) {
-        return switch (kodeverk) {
-            case PLEIEPENGER_SYKT_BARN -> Ytelser.PLEIEPENGER_SYKT_BARN;
-            case PLEIEPENGER_NÆRSTÅENDE -> Ytelser.PLEIEPENGER_NÆRSTÅENDE;
-            case OMSORGSPENGER -> Ytelser.OMSORGSPENGER;
-            case OPPLÆRINGSPENGER -> Ytelser.OPPLÆRINGSPENGER;
-
-            case ENGANGSTØNAD -> Ytelser.ENGANGSTØNAD;
-            case FORELDREPENGER -> Ytelser.FORELDREPENGER;
-            case SVANGERSKAPSPENGER -> Ytelser.SVANGERSKAPSPENGER;
-            case FRISINN -> Ytelser.FRISINN;
-            default -> null;
-        };
-    }
 
     public static class HentBrukersYtelserIPeriodeRequestAbacDataSupplier implements Function<Object, AbacDataAttributter> {
 
@@ -363,5 +307,17 @@ public class EksternDelingAvYtelserRestTjeneste {
         }
     }
 
+    public static class VedtakForPeriodeRequestAbacDataSupplier implements Function<Object, AbacDataAttributter> {
+
+        public VedtakForPeriodeRequestAbacDataSupplier() {
+        }
+
+        @Override
+        public AbacDataAttributter apply(Object obj) {
+            var req = (VedtakForPeriodeRequest) obj;
+            var attributeType = req.getIdent().erAktørId() ? StandardAbacAttributtType.AKTØR_ID : StandardAbacAttributtType.FNR;
+            return AbacDataAttributter.opprett().leggTil(attributeType, req.getIdent().getVerdi());
+        }
+    }
 
 }


### PR DESCRIPTION
Prøver å skille vedtak.ytelse fra iaygrunnlag - på sikt kanskje egen modul
* Expand med arbeidsgiverident
* Endepunkt og Request med kun vedtakYtelse-enums/objekt
* Samle mapping fra lagret til Ytelse

Omlegging: 
* Produsenter må populere arbeidsgiverIdent isf arbeidsgiver (fpsak, k9sak)
* Konsumenter må se på mapping fra AnvistAndel / arbeidsgiver - ser ut som kun fpsak + k9sak. 
* Ta i bruk nye endepunkt (fpsak). Hva brukes av /k9-tingene ?
* Motivere Tiltak og Sykepenger
