### PR TITLE
Farvel til openam

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -21,7 +21,6 @@
     "env": {
         "APPD_ENABLED": "false",
         "SECURITYTOKENSERVICE_URL": "https://sts-q1.preprod.local/SecurityTokenServiceProvider/",
-        "OIDC_OPEN_AM_WELL_KNOWN_URL": "https://isso-q.adeo.no:443/isso/oauth2/.well-known/openid-configuration",
         "OIDC_STS_WELL_KNOWN_URL": "https://security-token-service.nais.preprod.local/.well-known/openid-configuration",
         "ABAC_ATTRIBUTT_DRIFT": "no.nav.abac.attributter.resource.duplo.abakus.drift",
         "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -20,7 +20,6 @@
     "env": {
         "APPD_ENABLED": "true",
         "SECURITYTOKENSERVICE_URL": "https://sts.adeo.no/SecurityTokenServiceProvider/",
-        "OIDC_OPEN_AM_WELL_KNOWN_URL": "https://isso.adeo.no:443/isso/oauth2/.well-known/openid-configuration",
         "OIDC_STS_WELL_KNOWN_URL": "https://security-token-service.nais.adeo.no/.well-known/openid-configuration",
         "ABAC_ATTRIBUTT_DRIFT": "no.nav.abac.attributter.resource.duplo.abakus.drift",
         "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 
         <kontrakt.java.version>17</kontrakt.java.version>
 
-		<felles.version>4.2.14</felles.version>
-		<prosesstask.version>3.1.13</prosesstask.version>
+		<felles.version>4.2.16</felles.version>
+		<prosesstask.version>3.1.14</prosesstask.version>
         <maven.deploy.skip>true</maven.deploy.skip>
 		<kontrakter.version>6.1.31</kontrakter.version>
 	</properties>

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
@@ -41,8 +41,6 @@ import no.nav.foreldrepenger.abakus.app.konfig.EksternApiConfig;
 import no.nav.foreldrepenger.abakus.jetty.db.DatasourceRole;
 import no.nav.foreldrepenger.abakus.jetty.db.DatasourceUtil;
 import no.nav.foreldrepenger.konfig.Environment;
-import no.nav.vedtak.isso.IssoApplication;
-import no.nav.vedtak.sikkerhet.ContextPathHolder;
 import no.nav.vedtak.sikkerhet.jaspic.OidcAuthModule;
 
 public class JettyServer {
@@ -55,7 +53,6 @@ public class JettyServer {
 
     JettyServer(int serverPort) {
         this.serverPort = serverPort;
-        ContextPathHolder.instance(CONTEXT_PATH);
     }
 
     public static void main(String[] args) throws Exception {
@@ -155,7 +152,7 @@ public class JettyServer {
     }
 
     private static List<Class<?>> getApplicationClasses() {
-        return List.of(ApiConfig.class, EksternApiConfig.class, IssoApplication.class);
+        return List.of(ApiConfig.class, EksternApiConfig.class);
     }
 
     void bootStrap() throws Exception {

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,2 +1,0 @@
-# SSO callback url - bør bruke ingress for dette.
-loadbalancer.url=https://fpabakus.nais.preprod.local

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -1,2 +1,0 @@
-# SSO callback url - bør bruke ingress for dette.
-loadbalancer.url=https://fpabakus.nais.adeo.no

--- a/web/src/test/java/no/nav/foreldrepenger/abakus/app/konfig/RestApiAbacTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/abakus/app/konfig/RestApiAbacTest.java
@@ -12,11 +12,8 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Request;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import no.nav.vedtak.isso.config.ServerInfo;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
@@ -26,18 +23,6 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 public class RestApiAbacTest {
 
     private static String PREV_LB_URL;
-
-    @BeforeAll
-    public static void setup() {
-        PREV_LB_URL = System.setProperty(ServerInfo.PROPERTY_KEY_LOADBALANCER_URL, "http://localhost:8090");
-    }
-
-    @AfterAll
-    public static void teardown() {
-        if (PREV_LB_URL != null) {
-            System.setProperty(ServerInfo.PROPERTY_KEY_LOADBALANCER_URL, PREV_LB_URL);
-        }
-    }
 
     /**
      * IKKE ignorer denne testen, sikrer at REST-endepunkter får tilgangskontroll

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -1,8 +1,6 @@
 # Jetty
 server.port=8015
 
-loadbalancer.url=http://localhost:8015
-
 # Systembruker
 systembruker.username=vtp
 systembruker.password=vtp
@@ -14,11 +12,6 @@ abac.pdp.endpoint.url=http://localhost:8060/rest/asm-pdp/authorize
 
 # OIDC/STS
 oidc.sts.well.known.url=http://localhost:8060/rest/v1/sts/.well-known/openid-configuration
-
-# OIDC/OPENAM
-oidc.open.am.well.known.url=http://localhost:8060/rest/isso/oauth2/.well-known/openid-configuration
-oidc.open.am.client.id=fpabakus-localhost
-# oidc.open.am.client.secret=<trenges ikke>
 
 # STS web service
 securityTokenService.url=https://localhost:8063/soap/SecurityTokenServiceProvider/


### PR DESCRIPTION
Abakus vil bare svare på Authorization / Bearer - vil ikke se etter cookies/ID_token (med mindre vi setter opp ContextPathHolder med cookiepeath "/" eller "/k9"