### PR TITLE
Legger på AD grupper som kan kreve OBO tokens fra abakus

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -20,6 +20,13 @@
     "env": {
         "APPD_ENABLED": "false"
     },
+    "groups": [
+        "27e77109-fef2-48ce-a174-269074490353",
+        "8cddda87-0a22-4d35-9186-a2c32a6ab450",
+        "93e8903d-5c3f-4cbe-929e-0afeb22dec73",
+        "5bc5cae2-3ef9-4897-9828-766757299de8",
+        "5a7b4d5e-f80b-451c-aae2-2ab1c90f039d"
+    ],
     "AZURE_IAC_RULES": [
         {
             "app": "fp-swagger",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -56,12 +56,16 @@ spec:
      value: "{{this}}"
   {{/each}}
   azure:
-      application:
-          enabled: true
-          claims:
-              extra:
-                  - "NAVident"
-                  - "azp_name"
+    application:
+      enabled: true
+      claims:
+        extra:
+          - "NAVident"
+          - "azp_name"
+        groups:
+          {{#each groups as |group|}}
+          - id: "{{group}}"
+          {{/each}}
   {{#if AZURE_IAC_RULES}}
   accessPolicy:
     inbound:

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -20,6 +20,13 @@
     "env": {
         "APPD_ENABLED": "true"
     },
+    "groups": [
+        "73107205-17ec-4a07-a56e-e0a8542f90c9",
+        "77f05833-ebfd-45fb-8be7-88eca8e7418f",
+        "466d0df7-22ba-4c68-b848-73478cfd0486",
+        "be11a922-59a2-4afa-b5ad-b9e9bd445268",
+        "04b22158-354a-483f-a836-cf19b17ba5c3"
+    ],
     "AZURE_IAC_RULES": [
         {
             "app": "fp-swagger",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![](https://github.com/navikt/fp-abakus/workflows/Bygg%20og%20deploy/badge.svg) 
-[![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=navikt_fp-abakus&metric=alert_status)](https://sonarcloud.io/dashboard?id=navikt_fp-abakus) 
+![](https://github.com/navikt/fp-abakus/workflows/Bygg%20og%20deploy/badge.svg)
+[![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=navikt_fp-abakus&metric=alert_status)](https://sonarcloud.io/dashboard?id=navikt_fp-abakus)
 [![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=navikt_fp-abakus&metric=coverage)](https://sonarcloud.io/component_measures/metric/coverage/list?id=navikt_fp-abakus)
 [![SonarCloud Bugs](https://sonarcloud.io/api/project_badges/measure?project=navikt_fp-abakus&metric=bugs)](https://sonarcloud.io/component_measures/metric/reliability_rating/list?id=navikt_fp-abakus)
 [![SonarCloud Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=navikt_fp-abakus&metric=vulnerabilities)](https://sonarcloud.io/component_measures/metric/security_rating/list?id=navikt_fp-abakus)
@@ -24,3 +24,13 @@ Hvert grunnlag er immutable, men består av ett eller flere 'aggregater' (DDD te
 ### Linker
 [Foreldrepengeprosjektet på Confluence](http://confluence.adeo.no/display/MODNAV/Foreldrepengeprosjektet)
 
+### Sikkerhet
+Det er mulig å kalle tjenesten med bruk av følgende tokens
+- Azure CC
+- Azure OBO med følgende rettigheter:
+    - fpsak-saksbehandler
+    - fpsak-veileder
+    - k9-saksbehandler
+    - k9-veileder
+    - abakus-drift
+- STS (fases ut)

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,6 +1,4 @@
 ## Sikkerhet
-# STS
-securitytokenservice.url=https://sts-q1.preprod.local/SecurityTokenServiceProvider/
 
 # OIDC/STS
 oidc.sts.well.known.url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -1,6 +1,4 @@
 ## Sikkerhet
-# STS
-securitytokenservice.url=https://sts.adeo.no/SecurityTokenServiceProvider/
 
 # OIDC/STS
 oidc.sts.well.known.url=https://security-token-service.nais.adeo.no/.well-known/openid-configuration

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -18,9 +18,6 @@ oidc.open.am.client.id=fpabakus-localhost
 # OIDC/STS
 oidc.sts.well.known.url=http://localhost:8060/rest/v1/sts/.well-known/openid-configuration
 
-# STS web service
-securityTokenService.url=https://localhost:8063/soap/SecurityTokenServiceProvider/
-
 # Azure
 azure.app.well.known.url=http://authserver:8086/azureAd/.well-known/openid-configuration
 azure.app.client.id=fpabakus


### PR DESCRIPTION
Enforcet endring av NAIS https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619

Per i dag er det brukere fra følgende azure grupper som får lov å kommunisere med fpabakus med en OBO:
- fpsak-saksbehandler
- fpsak-veileder
- k9-saksbehandler
- k9-veileder
- abakus-drift (swagger)