### PR TITLE
Bytter til nye healthcheck endepunkter. Deprecate de gamle.

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -13,20 +13,20 @@ spec:
     - {{url}}
   {{/each}}
   liveness:
-    path: /fpabakus/internal/isAlive
+    path: /fpabakus/internal/health/isAlive
     initialDelay: 10
     periodSeconds: 10
     failureThreshold: 20
     timeout: 3
   readiness:
-    path: /fpabakus/internal/isReady
+    path: /fpabakus/internal/health/isReady
     initialDelay: 10
     periodSeconds: 10
     failureThreshold: 20
     timeout: 3
   preStopHook:
     http:
-      path: /fpabakus/internal/preStop
+      path: /fpabakus/internal/health/preStop
   prometheus:
     enabled: true
     path: /fpabakus/internal/metrics/prometheus

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/app/selftest/HealthCheckRestService.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/app/selftest/HealthCheckRestService.java
@@ -36,7 +36,7 @@ public class HealthCheckRestService {
     }
 
     @GET
-    @Path("/isAlive")
+    @Path("/health/isAlive")
     @Operation(description = "sjekker om poden lever", tags = "nais", hidden = true)
     public Response isAlive() {
         if (starterService.isKafkaAlive()) {
@@ -46,8 +46,19 @@ public class HealthCheckRestService {
         }
     }
 
+    /**
+     * @deprecated Både k9-verdikjede og fpsak-autotest trenger å bytte til det nye endepunkt /internal/health/isAlive
+     */
+    @Deprecated(since = "03.2023", forRemoval = true)
     @GET
-    @Path("/isReady")
+    @Path("/isAlive")
+    @Operation(description = "sjekker om poden lever", tags = "nais", hidden = true)
+    public Response isAliveDeprecated() {
+        return isAlive();
+    }
+
+    @GET
+    @Path("/health/isReady")
     @Operation(description = "sjekker om poden er klar", tags = "nais", hidden = true)
     public Response isReady() {
         if (databaseHealthCheck.isReady()) {
@@ -57,8 +68,19 @@ public class HealthCheckRestService {
         }
     }
 
+    /**
+     * @deprecated Både k9-verdikjede og fpsak-autotest trenger å bytte til det nye endepunkt /internal/health/isReady
+     */
+    @Deprecated(since = "03.2023", forRemoval = true)
     @GET
-    @Path("/preStop")
+    @Path("/isReady")
+    @Operation(description = "sjekker om poden er klar", tags = "nais", hidden = true)
+    public Response isReadyDeprecated() {
+        return isReady();
+    }
+
+    @GET
+    @Path("/health/preStop")
     @Operation(description = "kalles på før stopp", tags = "nais", hidden = true)
     public Response preStop() {
         starterService.stopServices();

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/DatasourceRole.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/DatasourceRole.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.abakus.jetty;
+
+enum DatasourceRole {
+    USER,
+    ADMIN,
+    READONLY
+}

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/DatasourceUtil.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/DatasourceUtil.java
@@ -1,4 +1,6 @@
-package no.nav.foreldrepenger.abakus.jetty.db;
+package no.nav.foreldrepenger.abakus.jetty;
+
+import java.util.Properties;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -7,22 +9,24 @@ import io.micrometer.core.instrument.Metrics;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vault.jdbc.hikaricp.HikariCPVaultUtil;
 import no.nav.vault.jdbc.hikaricp.VaultError;
+import no.nav.vedtak.exception.TekniskException;
 
-import java.util.Properties;
-
-public class DatasourceUtil {
+class DatasourceUtil {
 
     private static final Environment ENV = Environment.current();
 
-    public static HikariDataSource createDatasource(DatasourceRole role, int maxPoolSize) {
-        HikariConfig config = initConnectionPoolConfig(maxPoolSize);
+    private DatasourceUtil() {
+    }
+
+    static HikariDataSource createDatasource(DatasourceRole role, int maxPoolSize) {
+        var config = initConnectionPoolConfig(maxPoolSize);
         if (ENV.isVTP() || ENV.isLocal()) {
             return createLocalDatasource(config);
         }
         return createVaultDatasource(config, mountPath(), getRole(role));
     }
 
-    public static String getRole(DatasourceRole role) {
+    static String getRole(DatasourceRole role) {
         return String.format("%s-%s", getUsername(), role.name().toLowerCase());
     }
 
@@ -65,7 +69,7 @@ public class DatasourceUtil {
         try {
             return HikariCPVaultUtil.createHikariDataSourceWithVaultIntegration(config, mountPath, role);
         } catch (VaultError vaultError) {
-            throw new RuntimeException("Vault feil ved opprettelse av databaseforbindelse", vaultError);
+            throw new TekniskException("VAULT-ERROR", "Vault feil ved opprettelse av databaseforbindelse", vaultError);
         }
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
@@ -36,8 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import no.nav.foreldrepenger.abakus.jetty.db.DatasourceRole;
-import no.nav.foreldrepenger.abakus.jetty.db.DatasourceUtil;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.sikkerhet.jaspic.OidcAuthModule;
 

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/db/DatasourceRole.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/jetty/db/DatasourceRole.java
@@ -1,7 +1,0 @@
-package no.nav.foreldrepenger.abakus.jetty.db;
-
-public enum DatasourceRole {
-    USER,
-    ADMIN,
-    READONLY
-}

--- a/web/src/test/java/no/nav/foreldrepenger/abakus/jetty/JettyDevServer.java
+++ b/web/src/test/java/no/nav/foreldrepenger/abakus/jetty/JettyDevServer.java
@@ -5,8 +5,6 @@ import org.flywaydb.core.api.FlywayException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.abakus.jetty.db.DatasourceRole;
-import no.nav.foreldrepenger.abakus.jetty.db.DatasourceUtil;
 import no.nav.foreldrepenger.konfig.Environment;
 
 public class JettyDevServer extends JettyServer {


### PR DESCRIPTION
Man trenger å erstatt `/fpabakus/internal/isReady` med `/fpabakus/internal/health/isReady` og `/fpabakus/internal/isAlive` med `/fpabakus/internal/health/isAlive` i både fpsak-autotest og k9-verdikjede.

Enn så lenge er begge muligheter tilgjengelig. 