### PR TITLE
Fix: Rydder ubrukte ingresser.

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -13,7 +13,6 @@
     "mem": "1024Mi"
   },
   "ingresses": [
-    "https://fpabakus.nais.preprod.local",
     "https://fpabakus.dev.intern.nav.no",
     "https://fpabakus.dev-fss-pub.nais.io"
   ],

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -13,7 +13,6 @@
     "mem": "1024Mi"
   },
   "ingresses": [
-    "https://fpabakus.nais.adeo.no",
     "https://fpabakus.intern.nav.no",
     "https://fpabakus.prod-fss-pub.nais.io"
   ],


### PR DESCRIPTION
Brukes ikke i [prod](https://logs.adeo.no/s/nav-logs-legacy/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d%2Fd,to:now))&_a=(columns:!(level,message,envclass,application,pod,x_requested_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:application,negate:!f,params:(query:controller),type:phrase),query:(match_phrase:(application:controller))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:x_host,negate:!f,params:(query:fpabakus.nais.adeo.no),type:phrase),query:(match_phrase:(x_host:fpabakus.nais.adeo.no)))),index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',interval:auto,query:(language:kuery,query:'NOT%20isAlive%20'),sort:!(!('@timestamp',desc))))

Brukes ikke i [dev](https://logs.adeo.no/s/nav-logs-legacy/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d%2Fd,to:now))&_a=(columns:!(level,message,envclass,application,pod,x_requested_uri),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:envclass,negate:!f,params:(query:q),type:phrase),query:(match_phrase:(envclass:q))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:application,negate:!f,params:(query:controller),type:phrase),query:(match_phrase:(application:controller))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',key:x_host,negate:!f,params:(query:fpabakus.nais.preprod.local),type:phrase),query:(match_phrase:(x_host:fpabakus.nais.preprod.local)))),index:'7304a984-dbca-4e06-bd4b-70e5c7c97f59',interval:auto,query:(language:kuery,query:'NOT%20isAlive%20'),sort:!(!('@timestamp',desc))))

sist registrert trafikk fra den 24.02.2023