### PR TITLE
Skille arbeidsprosent og utbetalingsprosent

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtaleBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/AktivitetsAvtaleBuilder.java
@@ -30,7 +30,7 @@ public class AktivitetsAvtaleBuilder {
     }
 
     public AktivitetsAvtaleBuilder medProsentsats(BigDecimal prosentsats) {
-        this.aktivitetsAvtaleEntitet.setProsentsats(prosentsats == null ? Stillingsprosent.nullProsent() : new Stillingsprosent(prosentsats));
+        this.aktivitetsAvtaleEntitet.setProsentsats(prosentsats == null ? Stillingsprosent.nullProsent() : Stillingsprosent.arbeid(prosentsats));
         return this;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/PermisjonBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/PermisjonBuilder.java
@@ -1,10 +1,10 @@
 package no.nav.foreldrepenger.abakus.domene.iay;
 
-import no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType;
-import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
+
+import no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType;
+import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
 
 public class PermisjonBuilder {
     private final Permisjon permisjon;
@@ -23,7 +23,7 @@ public class PermisjonBuilder {
     }
 
     public PermisjonBuilder medProsentsats(BigDecimal prosentsats) {
-        this.permisjon.setProsentsats(new Stillingsprosent(prosentsats));
+        this.permisjon.setProsentsats(Stillingsprosent.arbeid(prosentsats));
         return this;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistAndelBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistAndelBuilder.java
@@ -1,11 +1,11 @@
 package no.nav.foreldrepenger.abakus.domene.iay;
 
+import java.math.BigDecimal;
+
 import no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori;
 import no.nav.foreldrepenger.abakus.typer.Beløp;
 import no.nav.foreldrepenger.abakus.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-
-import java.math.BigDecimal;
 
 public class YtelseAnvistAndelBuilder {
     private final YtelseAnvistAndel ytelseAnvistAndel;
@@ -27,14 +27,14 @@ public class YtelseAnvistAndelBuilder {
 
     public YtelseAnvistAndelBuilder medUtbetalingsgrad(BigDecimal verdi) {
         if (verdi != null) {
-            this.ytelseAnvistAndel.setUtbetalingsgradProsent(new Stillingsprosent(verdi));
+            this.ytelseAnvistAndel.setUtbetalingsgradProsent(Stillingsprosent.utbetalingsgrad(verdi));
         }
         return this;
     }
 
     public YtelseAnvistAndelBuilder medRefusjonsgrad(BigDecimal verdi) {
         if (verdi != null) {
-            this.ytelseAnvistAndel.setRefusjonsgradProsent(new Stillingsprosent(verdi));
+            this.ytelseAnvistAndel.setRefusjonsgradProsent(Stillingsprosent.utbetalingsgrad(verdi));
         }
         return this;
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseAnvistBuilder.java
@@ -38,7 +38,7 @@ public class YtelseAnvistBuilder {
 
     public YtelseAnvistBuilder medUtbetalingsgradProsent(BigDecimal utbetalingsgradProsent) {
         if (utbetalingsgradProsent != null) {
-            this.ytelseAnvist.setUtbetalingsgradProsent(new Stillingsprosent(utbetalingsgradProsent));
+            this.ytelseAnvist.setUtbetalingsgradProsent(Stillingsprosent.utbetalingsgrad(utbetalingsgradProsent));
         }
         return this;
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseGrunnlagBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/YtelseGrunnlagBuilder.java
@@ -24,17 +24,17 @@ public class YtelseGrunnlagBuilder {
     }
 
     public YtelseGrunnlagBuilder medDekningsgradProsent(BigDecimal prosent) {
-        this.ytelseGrunnlag.setDekningsgradProsent(new Stillingsprosent(prosent));
+        this.ytelseGrunnlag.setDekningsgradProsent(Stillingsprosent.utbetalingsgrad(prosent));
         return this;
     }
 
     public YtelseGrunnlagBuilder medGraderingProsent(BigDecimal prosent) {
-        this.ytelseGrunnlag.setGraderingProsent(new Stillingsprosent(prosent));
+        this.ytelseGrunnlag.setGraderingProsent(Stillingsprosent.utbetalingsgrad(prosent));
         return this;
     }
 
     public YtelseGrunnlagBuilder medInntektsgrunnlagProsent(BigDecimal prosent) {
-        this.ytelseGrunnlag.setInntektsgrunnlagProsent(new Stillingsprosent(prosent));
+        this.ytelseGrunnlag.setInntektsgrunnlagProsent(Stillingsprosent.utbetalingsgrad(prosent));
         return this;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/Gradering.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/inntektsmelding/Gradering.java
@@ -16,7 +16,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
 import no.nav.abakus.iaygrunnlag.kodeverk.IndexKey;
 import no.nav.foreldrepenger.abakus.felles.diff.ChangeTracked;
 import no.nav.foreldrepenger.abakus.felles.diff.IndexKeyComposer;
@@ -58,7 +57,7 @@ public class Gradering extends BaseEntitet implements IndexKey {
     }
 
     public Gradering(LocalDate fom, LocalDate tom, BigDecimal arbeidstidProsent) {
-        this(tom == null ? IntervallEntitet.fraOgMed(fom) : IntervallEntitet.fraOgMedTilOgMed(fom, tom), new Stillingsprosent(arbeidstidProsent));
+        this(tom == null ? IntervallEntitet.fraOgMed(fom) : IntervallEntitet.fraOgMedTilOgMed(fom, tom), Stillingsprosent.arbeid(arbeidstidProsent));
     }
 
     Gradering(Gradering gradering) {

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapArbeidsforholdInformasjon.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/dto/iay/MapArbeidsforholdInformasjon.java
@@ -82,7 +82,7 @@ class MapArbeidsforholdInformasjon {
                 .medNyArbeidsforholdRef(nyArbeidsgiverRef)
                 .medHandling(ov.getHandling())
                 .medAngittArbeidsgiverNavn(ov.getAngittArbeidsgiverNavn())
-                .medAngittStillingsprosent(new Stillingsprosent(ov.getStillingsprosent()));
+                .medAngittStillingsprosent(Stillingsprosent.arbeid(ov.getStillingsprosent()));
 
             ov.getBekreftetPermisjon().ifPresent(bp -> {
                 BekreftetPermisjonStatus bekreftetPermisjonStatus = bp.getBekreftetPermisjonStatus();

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/ArbeidsforholdTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/arbeidsforhold/ArbeidsforholdTjeneste.java
@@ -7,14 +7,11 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
-import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
 import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.rest.AaregRestKlient;
 import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.rest.ArbeidsavtaleRS;
@@ -25,6 +22,7 @@ import no.nav.foreldrepenger.abakus.registerdata.arbeidsforhold.rest.PermisjonPe
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.EksternArbeidsforholdRef;
 import no.nav.foreldrepenger.abakus.typer.PersonIdent;
+import no.nav.foreldrepenger.abakus.typer.Stillingsprosent;
 
 @ApplicationScoped
 public class ArbeidsforholdTjeneste {
@@ -126,7 +124,7 @@ public class ArbeidsforholdTjeneste {
     }
 
     private Arbeidsavtale byggArbeidsavtaleRS(ArbeidsavtaleRS arbeidsavtale, ArbeidsforholdRS arbeidsforhold) {
-        var stillingsprosent = Stillingsprosent.normaliserData(arbeidsavtale.stillingsprosent());
+        var stillingsprosent = Stillingsprosent.normaliserStillingsprosentArbeid(arbeidsavtale.stillingsprosent());
         Arbeidsavtale.Builder builder = new Arbeidsavtale.Builder().medStillingsprosent(stillingsprosent)
             .medSisteLønnsendringsdato(arbeidsavtale.sistLoennsendring());
 

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/infotrygd/InfotrygdgrunnlagAnvistAndelMapper.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/infotrygd/InfotrygdgrunnlagAnvistAndelMapper.java
@@ -260,7 +260,7 @@ public class InfotrygdgrunnlagAnvistAndelMapper {
         return utbetalinger.stream()
             .map(u -> new Mellomregninger(
                 OrganisasjonsNummerValidator.erGyldig(u.getOrgnr()) ? Arbeidsgiver.virksomhet(new OrgNummer(u.getOrgnr())) : null,
-                new Beløp(u.getDagsats()), new Stillingsprosent(u.getUtbetalingsgrad()), u.getErRefusjon() != null && u.getErRefusjon(), false,
+                new Beløp(u.getDagsats()), Stillingsprosent.utbetalingsgrad(u.getUtbetalingsgrad()), u.getErRefusjon() != null && u.getErRefusjon(), false,
                 u.getOrgnr() != null && Arrays.stream(Nødnummer.values()).anyMatch(n -> n.getOrgnummer().equals(u.getOrgnr()))))
             .toList();
     }

--- a/domenetjenester/kobling/src/test/java/no/nav/foreldrepenger/abakus/typer/StillingsprosentTest.java
+++ b/domenetjenester/kobling/src/test/java/no/nav/foreldrepenger/abakus/typer/StillingsprosentTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.abakus.typer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,15 +17,22 @@ class StillingsprosentTest {
     }
 
     @Test
-    void skalReturnereTidelVerdiHvisStørrereEn500() {
-        Stillingsprosent minus = new Stillingsprosent(BigDecimal.valueOf(600));
+    void skalReturnereTidelVerdiHvisStørrereEnn110() {
+        Stillingsprosent minus = Stillingsprosent.arbeid(BigDecimal.valueOf(600));
 
         assertThat(minus.getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(60));
     }
 
     @Test
-    void skalReturnereTidelHvisMinusOgStørrereEn500() {
-        Stillingsprosent minus = new Stillingsprosent(BigDecimal.valueOf(-600));
+    void skalReturnereUtbetalingsgradVerdiHvisStørrereEnn100() {
+        Stillingsprosent minus = Stillingsprosent.utbetalingsgrad(BigDecimal.valueOf(200));
+
+        assertThat(minus.getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(200));
+    }
+
+    @Test
+    void skalReturnereTidelHvisMinusOgStørrereEnn110() {
+        Stillingsprosent minus = Stillingsprosent.arbeid(BigDecimal.valueOf(-600));
 
         assertThat(minus.getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(60));
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseAndelBuilder.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/VedtakYtelseAndelBuilder.java
@@ -26,14 +26,14 @@ public class VedtakYtelseAndelBuilder {
 
     public VedtakYtelseAndelBuilder medUtbetalingsgrad(BigDecimal verdi) {
         if (verdi != null) {
-            this.vedtakYtelseAndel.setUtbetalingsgradProsent(new Stillingsprosent(verdi));
+            this.vedtakYtelseAndel.setUtbetalingsgradProsent(Stillingsprosent.utbetalingsgrad(verdi));
         }
         return this;
     }
 
     public VedtakYtelseAndelBuilder medRefusjonsgrad(BigDecimal verdi) {
         if (verdi != null) {
-            this.vedtakYtelseAndel.setRefusjonsgradProsent(new Stillingsprosent(verdi));
+            this.vedtakYtelseAndel.setRefusjonsgradProsent(Stillingsprosent.utbetalingsgrad(verdi));
         }
         return this;
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistBuilder.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/domene/YtelseAnvistBuilder.java
@@ -43,7 +43,7 @@ public class YtelseAnvistBuilder {
 
     public YtelseAnvistBuilder medUtbetalingsgradProsent(BigDecimal utbetalingsgradProsent) {
         if (utbetalingsgradProsent != null) {
-            this.ytelseAnvist.setUtbetalingsgradProsent(new Stillingsprosent(utbetalingsgradProsent));
+            this.ytelseAnvist.setUtbetalingsgradProsent(Stillingsprosent.utbetalingsgrad(utbetalingsgradProsent));
         }
         return this;
     }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/arbeid/v1/AktivitetsAvtaleDto.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/arbeid/v1/AktivitetsAvtaleDto.java
@@ -4,18 +4,17 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import no.nav.abakus.iaygrunnlag.Periode;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,27 +37,6 @@ public class AktivitetsAvtaleDto {
     @DecimalMin(value = "0.00", message = "stillingsprosent [${validatedValue}] må være >= {value}")
     @DecimalMax(value = "1000.00", message = "stillingsprosent [${validatedValue}] må være <= {value}")
     private BigDecimal stillingsprosent;
-
-    /**
-     * For timelønnede så vil antallet timer i arbeidsavtalen være satt her.
-     * Merk her er registrert mye søppel i Aareg, så brukes først og fremst til kontroll når det er en verdi. Eks.kan være registrert antall
-     * timer per år (men skal være per uke)
-     */
-    @JsonProperty("antallTimer")
-    @DecimalMin(value = "0.00", message = "antallTimer [${validatedValue}] må være >= {value}")
-    @DecimalMax(value = "2000.00", message = "antallTimer [${validatedValue}] må være <= {value}")
-    private BigDecimal antallTimer;
-
-    /**
-     * Antall timer som tilsvarer fulltid (f.eks 40 timer). Merk her er registrert mye søppel ved input fra Aareg. Bruker derfor først og fremst
-     * til kontroll når det er satt en verdi.
-     * Eks. kan være registrert antall timer full tid per år (når det skal være per uke), eller antall timer per uke totalt (eks. 168 timers
-     * arbeidsuker).
-     */
-    @JsonProperty("antallTimerFulltid")
-    @DecimalMin(value = "0.00", message = "antallTimerFulltid [${validatedValue}] må være >= {value}")
-    @DecimalMax(value = "2000.00", message = "antallTimerFulltid [${validatedValue}] må være <= {value}")
-    private BigDecimal antallTimerFulltid;
 
     @JsonProperty("sistLønnsendring")
     @Valid
@@ -109,30 +87,6 @@ public class AktivitetsAvtaleDto {
         this.stillingsprosent = stillingsprosent == null ? null : stillingsprosent.setScale(2, RoundingMode.HALF_UP);
     }
 
-    public BigDecimal getAntallTimer() {
-        return antallTimer;
-    }
-
-    public void setAntallTimer(BigDecimal antallTimer) {
-        this.antallTimer = antallTimer == null ? null : antallTimer.setScale(2, RoundingMode.HALF_UP);
-    }
-
-    public void setAntallTimer(int timer) {
-        this.setAntallTimer(BigDecimal.valueOf(timer));
-    }
-
-    public BigDecimal getAntallTimerFulltid() {
-        return antallTimerFulltid;
-    }
-
-    public void setAntallTimerFulltid(BigDecimal antallTimerFulltid) {
-        this.antallTimerFulltid = antallTimerFulltid == null ? null : antallTimerFulltid.setScale(2, RoundingMode.HALF_UP);
-    }
-
-    public void setAntallTimerFulltid(int timer) {
-        this.setAntallTimerFulltid(BigDecimal.valueOf(timer));
-    }
-
     public AktivitetsAvtaleDto medStillingsprosent(BigDecimal stillingsprosent) {
         setStillingsprosent(stillingsprosent);
         return this;
@@ -140,26 +94,6 @@ public class AktivitetsAvtaleDto {
 
     public AktivitetsAvtaleDto medStillingsprosent(int prosentHeltall) {
         setStillingsprosent(BigDecimal.valueOf(prosentHeltall));
-        return this;
-    }
-
-    public AktivitetsAvtaleDto medAntallTimer(BigDecimal timer) {
-        setAntallTimer(timer);
-        return this;
-    }
-
-    public AktivitetsAvtaleDto medAntallTimer(int timer) {
-        setAntallTimer(timer);
-        return this;
-    }
-
-    public AktivitetsAvtaleDto medAntallTimerFulltid(BigDecimal timer) {
-        setAntallTimerFulltid(timer);
-        return this;
-    }
-
-    public AktivitetsAvtaleDto medAntallTimerFulltid(int timer) {
-        setAntallTimerFulltid(timer);
         return this;
     }
 


### PR DESCRIPTION
Jeg bommet på utbetalingsprosent fra Arena i merge 4/3. Denne skiller arbeid/aareg og utbetaling/diverse.
Bør også release ny versjon av kontrakt.
Må finne alle tilfelle av iay_relatert_ytelse med kilde Arena og ytelse_anvist / utbetaling < 109 siden 4/3 start of day.