### PR TITLE
Endre til info siden man skal hente opp mange gamle saker ifm HR-saken

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdInformasjon.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/domene/iay/arbeidsforhold/ArbeidsforholdInformasjon.java
@@ -288,7 +288,7 @@ public class ArbeidsforholdInformasjon extends BaseEntitet {
         for (var e : gruppertArbeidsforhold.entrySet()) {
             if (e.getValue().size() > 1) {
                 String msg = String.format("Duplikat internref for %s=%s", e.getKey(), e.getValue());
-                LOG.warn(msg);
+                LOG.info(msg);
                 //throw new IllegalStateException(msg);
             }
         }


### PR DESCRIPTION
Meldingen "Duplikat internref for" kommer når man åpner eldre saker. Det er en del slike oppslag pga HR-dommen. 
Dermed gir nivå warning en del loggstøy. 
Situasjonen skal ikke forekomme for nyere saker og det spørs om vi vil rydde de gamle grunnlagene - en vakker dag