### PR TITLE
TFP-5972 innledende gjennomgang av requestbuilder

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/ArbeidsforholdRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/ArbeidsforholdRestTjeneste.java
@@ -18,12 +18,12 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import no.nav.abakus.iaygrunnlag.request.AktørDatoRequest;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.arbeidsforhold.ArbeidsforholdDtoTjeneste;
 import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
-import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
@@ -73,7 +73,7 @@ public class ArbeidsforholdRestTjeneste {
         @Override
         public AbacDataAttributter apply(Object obj) {
             AktørDatoRequest req = (AktørDatoRequest) obj;
-            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.AKTØR_ID, req.getAktør().getIdent());
+            return IdentDataAttributter.abacAttributterForPersonIdent(req.getAktør());
         }
     }
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
@@ -31,8 +31,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
-import no.nav.abakus.iaygrunnlag.FnrPersonident;
 import no.nav.abakus.iaygrunnlag.Periode;
 import no.nav.abakus.iaygrunnlag.PersonIdent;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdInformasjon;
@@ -48,6 +46,7 @@ import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.abakus.domene.iay.InntektArbeidYtelseGrunnlagBuilder;
 import no.nav.foreldrepenger.abakus.felles.LoggUtil;
 import no.nav.foreldrepenger.abakus.felles.jpa.IntervallEntitet;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.IAYFraDtoMapper;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.IAYTilDtoMapper;
@@ -59,7 +58,6 @@ import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
-import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 
@@ -82,15 +80,7 @@ public class GrunnlagRestTjeneste {
     }
 
     private static AbacDataAttributter lagAbacAttributter(PersonIdent person) {
-        var abacDataAttributter = AbacDataAttributter.opprett();
-        String ident = person.getIdent();
-        String identType = person.getIdentType();
-        if (FnrPersonident.IDENT_TYPE.equals(identType)) {
-            return abacDataAttributter.leggTil(StandardAbacAttributtType.FNR, ident);
-        } else if (AktørIdPersonident.IDENT_TYPE.equals(identType)) {
-            return abacDataAttributter.leggTil(StandardAbacAttributtType.AKTØR_ID, ident);
-        }
-        throw new java.lang.IllegalStateException("Ukjent identtype" + identType);
+        return IdentDataAttributter.abacAttributterForPersonIdent(person);
     }
 
     @POST

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/InntektsmeldingerRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/InntektsmeldingerRestTjeneste.java
@@ -27,8 +27,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
-import no.nav.abakus.iaygrunnlag.FnrPersonident;
 import no.nav.abakus.iaygrunnlag.PersonIdent;
 import no.nav.abakus.iaygrunnlag.UuidDto;
 import no.nav.abakus.iaygrunnlag.inntektsmelding.v1.InntektsmeldingerDto;
@@ -38,6 +36,7 @@ import no.nav.abakus.iaygrunnlag.request.InntektsmeldingerRequest;
 import no.nav.foreldrepenger.abakus.domene.iay.arbeidsforhold.ArbeidsforholdInformasjonBuilder;
 import no.nav.foreldrepenger.abakus.domene.iay.inntektsmelding.Inntektsmelding;
 import no.nav.foreldrepenger.abakus.felles.LoggUtil;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.foreldrepenger.abakus.iay.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.abakus.iay.InntektsmeldingerTjeneste;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.MapInntektsmeldinger;
@@ -48,7 +47,6 @@ import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
-import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
@@ -153,7 +151,7 @@ public class InntektsmeldingerRestTjeneste {
         @Override
         public AbacDataAttributter apply(Object obj) {
             var req = (InntektsmeldingerMottattRequest) obj;
-            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.AKTØR_ID, req.getAktør().getIdent());
+            return IdentDataAttributter.abacAttributterForPersonIdent(req.getAktør());
         }
 
     }
@@ -173,13 +171,7 @@ public class InntektsmeldingerRestTjeneste {
 
         @Override
         public AbacDataAttributter abacAttributter() {
-            final var abacDataAttributter = AbacDataAttributter.opprett();
-            if (FnrPersonident.IDENT_TYPE.equals(getPerson().getIdentType())) {
-                return abacDataAttributter.leggTil(StandardAbacAttributtType.FNR, getPerson().getIdent());
-            } else if (AktørIdPersonident.IDENT_TYPE.equals(getPerson().getIdentType())) {
-                return abacDataAttributter.leggTil(StandardAbacAttributtType.AKTØR_ID, getPerson().getIdent());
-            }
-            throw new java.lang.IllegalArgumentException("Ukjent identtype: " + getPerson().getIdentType());
+            return IdentDataAttributter.abacAttributterForPersonIdent(getPerson());
         }
 
     }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/OppgittOpptjeningRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/iay/tjeneste/OppgittOpptjeningRestTjeneste.java
@@ -23,6 +23,7 @@ import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
 import no.nav.foreldrepenger.abakus.domene.iay.GrunnlagReferanse;
 import no.nav.foreldrepenger.abakus.domene.iay.søknad.OppgittOpptjeningBuilder;
 import no.nav.foreldrepenger.abakus.felles.LoggUtil;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.foreldrepenger.abakus.iay.OppgittOpptjeningTjeneste;
 import no.nav.foreldrepenger.abakus.iay.tjeneste.dto.iay.MapOppgittOpptjening;
 import no.nav.foreldrepenger.abakus.kobling.KoblingReferanse;
@@ -31,7 +32,6 @@ import no.nav.foreldrepenger.abakus.typer.AktørId;
 import no.nav.foreldrepenger.abakus.typer.Saksnummer;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
-import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
@@ -152,7 +152,7 @@ public class OppgittOpptjeningRestTjeneste {
         @Override
         public AbacDataAttributter apply(Object o) {
             var req = (OppgittOpptjeningMottattRequest) o;
-            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.AKTØR_ID, req.getAktør().getIdent());
+            return IdentDataAttributter.abacAttributterForPersonIdent(req.getAktør());
         }
     }
 }

--- a/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/tjeneste/RegisterdataRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/foreldrepenger/abakus/registerdata/tjeneste/RegisterdataRestTjeneste.java
@@ -1,16 +1,7 @@
 package no.nav.foreldrepenger.abakus.registerdata.tjeneste;
 
 import java.net.HttpURLConnection;
-import java.util.Set;
-import java.util.UUID;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.function.Function;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,25 +11,20 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
-import no.nav.abakus.iaygrunnlag.FnrPersonident;
-import no.nav.abakus.iaygrunnlag.Periode;
-import no.nav.abakus.iaygrunnlag.PersonIdent;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.InnhentRegisterdataRequest;
-import no.nav.abakus.iaygrunnlag.request.RegisterdataType;
 import no.nav.foreldrepenger.abakus.felles.LoggUtil;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.foreldrepenger.abakus.registerdata.tjeneste.dto.TaskResponsDto;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
-import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
+import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 
@@ -64,7 +50,7 @@ public class RegisterdataRestTjeneste {
     @Operation(description = "Trigger registerinnhenting for en gitt id", tags = "registerinnhenting")
     @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.APPLIKASJON, sporingslogg = true)
     @SuppressWarnings({"findsecbugs:JAXRS_ENDPOINT", "resource"})
-    public Response innhentOgLagreRegisterdataAsync(@Parameter(name = "innhent") @Valid InnhentRegisterdataAbacDto dto) {
+    public Response innhentOgLagreRegisterdataAsync(@Parameter(name = "innhent") @Valid @TilpassetAbacAttributt(supplierClass = InnhentSupplier.class) InnhentRegisterdataRequest dto) {
         Response response;
         if (!YtelseType.abakusYtelser().contains(dto.getYtelseType())) {
             return Response.status(HttpURLConnection.HTTP_BAD_REQUEST).build();
@@ -79,43 +65,13 @@ public class RegisterdataRestTjeneste {
         return response;
     }
 
-    /**
-     * Json bean med Abac.
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonInclude(value = Include.NON_ABSENT, content = Include.NON_EMPTY)
-    @JsonAutoDetect(fieldVisibility = Visibility.NONE, getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, isGetterVisibility = Visibility.NONE, creatorVisibility = Visibility.NONE)
-    public static class InnhentRegisterdataAbacDto extends InnhentRegisterdataRequest implements AbacDto {
-
-        @JsonCreator
-        public InnhentRegisterdataAbacDto(@JsonProperty(value = "saksnummer", required = true) @Valid @NotNull String saksnummer,
-                                          @JsonProperty(value = "referanse", required = true) @Valid @NotNull UUID referanse,
-                                          @JsonProperty(value = "ytelseType", required = true) @Valid @NotNull YtelseType ytelseType,
-                                          @JsonProperty(value = "opplysningsperiode", required = true) @NotNull @Valid Periode opplysningsperiode,
-                                          @JsonProperty(value = "aktør", required = true) @NotNull @Valid PersonIdent aktør,
-                                          @JsonProperty(value = "elementer", required = true) @NotNull @Valid Set<RegisterdataType> elementer) {
-            super(saksnummer, referanse, ytelseType, opplysningsperiode, aktør, elementer);
-        }
-
+    public static class InnhentSupplier implements Function<Object, AbacDataAttributter> {
         @Override
-        public AbacDataAttributter abacAttributter() {
-            AbacDataAttributter opprett = AbacDataAttributter.opprett();
-            if (getAnnenPartAktør() != null) {
-                leggTil(opprett, getAnnenPartAktør());
-            }
-            leggTil(opprett, getAktør());
-            return opprett;
+        public AbacDataAttributter apply(Object obj) {
+            var req = (InnhentRegisterdataRequest) obj;
+            return AbacDataAttributter.opprett()
+                .leggTil(IdentDataAttributter.abacAttributterForPersonIdent(req.getAktør()))
+                .leggTil(StandardAbacAttributtType.SAKSNUMMER, req.getSaksnummer());
         }
-
-        private void leggTil(AbacDataAttributter abac, PersonIdent person) {
-            if (person != null) {
-                if (FnrPersonident.IDENT_TYPE.equals(person.getIdentType())) {
-                    abac.leggTil(StandardAbacAttributtType.FNR, person.getIdent());
-                } else if (AktørIdPersonident.IDENT_TYPE.equals(person.getIdentType())) {
-                    abac.leggTil(StandardAbacAttributtType.AKTØR_ID, person.getIdent());
-                }
-            }
-        }
-
     }
 }

--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/IdentDataAttributter.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/IdentDataAttributter.java
@@ -1,0 +1,26 @@
+package no.nav.foreldrepenger.abakus.felles.sikkerhet;
+
+import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
+import no.nav.abakus.iaygrunnlag.FnrPersonident;
+import no.nav.abakus.iaygrunnlag.PersonIdent;
+import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
+import no.nav.vedtak.sikkerhet.abac.StandardAbacAttributtType;
+
+public final class IdentDataAttributter {
+
+    private IdentDataAttributter() {
+        // Skal ikke instansieres
+    }
+
+    public static AbacDataAttributter abacAttributterForPersonIdent(PersonIdent person) {
+        if (person != null && FnrPersonident.IDENT_TYPE.equals(person.getIdentType())) {
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.FNR, person.getIdent());
+        } else if (person != null && AktørIdPersonident.IDENT_TYPE.equals(person.getIdentType())) {
+            return AbacDataAttributter.opprett().leggTil(StandardAbacAttributtType.AKTØR_ID, person.getIdent());
+        } else {
+            return AbacDataAttributter.opprett();
+        }
+    }
+
+
+}

--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/PdpRequestBuilderImpl.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/PdpRequestBuilderImpl.java
@@ -8,9 +8,6 @@ import no.nav.vedtak.sikkerhet.abac.pdp.AppRessursData;
 import no.nav.vedtak.sikkerhet.abac.pipdata.PipBehandlingStatus;
 import no.nav.vedtak.sikkerhet.abac.pipdata.PipFagsakStatus;
 
-import static no.nav.vedtak.sikkerhet.abac.pdp.ForeldrepengerDataKeys.BEHANDLING_STATUS;
-import static no.nav.vedtak.sikkerhet.abac.pdp.ForeldrepengerDataKeys.FAGSAK_STATUS;
-
 /**
  * Implementasjon av PDP request for denne applikasjonen.
  */
@@ -18,13 +15,24 @@ import static no.nav.vedtak.sikkerhet.abac.pdp.ForeldrepengerDataKeys.FAGSAK_STA
 public class PdpRequestBuilderImpl implements PdpRequestBuilder {
 
     @Override
+    public AppRessursData lagAppRessursDataForSystembruker(AbacDataAttributter dataAttributter) {
+        return minimalbuilder().build();
+    }
+
+    @Override
     public AppRessursData lagAppRessursData(AbacDataAttributter dataAttributter) {
-        return AppRessursData.builder()
+
+        var builder = minimalbuilder()
             .leggTilAktørIdSet(dataAttributter.getVerdier(StandardAbacAttributtType.AKTØR_ID))
-            .leggTilFødselsnumre(dataAttributter.getVerdier(StandardAbacAttributtType.FNR))
-            // TODO: Hente fra pip-tjenesten? arv fra tidligere... men nå er 2 pips aktuelle ....
-            .leggTilRessurs(FAGSAK_STATUS, PipFagsakStatus.UNDER_BEHANDLING)
-            .leggTilRessurs(BEHANDLING_STATUS, PipBehandlingStatus.UTREDES)
-            .build();
+            .leggTilFødselsnumre(dataAttributter.getVerdier(StandardAbacAttributtType.FNR));
+        // TODO legg på saksnummer relevante steder (mange requests har saksnummer)
+        // Ta med denne dataAttributter.getVerdier(StandardAbacAttributtType.SAKSNUMMER).stream().findFirst().map(String::valueOf).ifPresent(builder::medSaksnummer);
+        return builder.build();
+    }
+
+    private AppRessursData.Builder minimalbuilder() {
+        return AppRessursData.builder()
+            .medFagsakStatus(PipFagsakStatus.UNDER_BEHANDLING)
+            .medBehandlingStatus(PipBehandlingStatus.UTREDES);
     }
 }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/AktørDatoRequest.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/AktørDatoRequest.java
@@ -3,9 +3,6 @@ package no.nav.abakus.iaygrunnlag.request;
 import java.time.LocalDate;
 import java.util.Objects;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13,7 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import no.nav.abakus.iaygrunnlag.Aktør;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import no.nav.abakus.iaygrunnlag.Periode;
 import no.nav.abakus.iaygrunnlag.PersonIdent;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
@@ -54,7 +52,7 @@ public class AktørDatoRequest {
         this.ytelse = ytelse;
     }
 
-    public Aktør getAktør() {
+    public PersonIdent getAktør() {
         return aktør;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
 	<groupId>no.nav.foreldrepenger.abakus</groupId>
@@ -35,9 +35,9 @@
 
         <kontrakt.java.version>21</kontrakt.java.version>
 
-		<felles.version>7.4.13</felles.version>
-		<prosesstask.version>5.1.4</prosesstask.version>
-		<kontrakter.version>9.2.6</kontrakter.version>
+		<felles.version>7.4.15</felles.version>
+		<prosesstask.version>5.1.5</prosesstask.version>
+		<kontrakter.version>9.2.7</kontrakter.version>
         <tidsserie.version>2.7.1</tidsserie.version>
 
         <!-- Forteller til maven-deploy-plugin at artefaktet ikke skal deployes.
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>3.6.6</version>
+                <version>3.6.7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/web/src/main/java/no/nav/foreldrepenger/abakus/kobling/KoblingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abakus/kobling/KoblingRestTjeneste.java
@@ -24,12 +24,11 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
-import no.nav.abakus.iaygrunnlag.FnrPersonident;
 import no.nav.abakus.iaygrunnlag.PersonIdent;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.AvsluttKoblingRequest;
 import no.nav.foreldrepenger.abakus.felles.LoggUtil;
+import no.nav.foreldrepenger.abakus.felles.sikkerhet.IdentDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
@@ -126,19 +125,10 @@ public class KoblingRestTjeneste {
         }
 
         private static AbacDataAttributter lagAbacAttributter(AvsluttKoblingRequestAbacDto dto) {
-            var abacDataAttributter = AbacDataAttributter.opprett();
-
-            abacDataAttributter.leggTil(StandardAbacAttributtType.SAKSNUMMER, dto.getSaksnummer());
-            abacDataAttributter.leggTil(StandardAbacAttributtType.BEHANDLING_UUID, dto.getReferanse());
-
-            String ident = dto.getAktør().getIdent();
-            String identType = dto.getAktør().getIdentType();
-            if (FnrPersonident.IDENT_TYPE.equals(identType)) {
-                return abacDataAttributter.leggTil(StandardAbacAttributtType.FNR, ident);
-            } else if (AktørIdPersonident.IDENT_TYPE.equals(identType)) {
-                return abacDataAttributter.leggTil(StandardAbacAttributtType.AKTØR_ID, ident);
-            }
-            throw new java.lang.IllegalStateException("Ukjent identtype" + identType);
+            return AbacDataAttributter.opprett()
+                .leggTil(StandardAbacAttributtType.SAKSNUMMER, dto.getSaksnummer())
+                .leggTil(StandardAbacAttributtType.BEHANDLING_UUID, dto.getReferanse())
+                .leggTil(IdentDataAttributter.abacAttributterForPersonIdent(dto.getAktør()));
         }
     }
 }


### PR DESCRIPTION
Oppdaterer felles mm. Fornyer PdpRequestBuilder men tar ikke med saksnummer i første omgang. 
De fleste requestene har både kobling (=behandling), saksnummer og aktør ... mulig vi innfører en kobling-attributt som slår opp saksnummer / aktør / behandling fra Kobling.