### PR TITLE
TFP-5972 felles 751

### DIFF
--- a/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/PdpRequestBuilderImpl.java
+++ b/felles/src/main/java/no/nav/foreldrepenger/abakus/felles/sikkerhet/PdpRequestBuilderImpl.java
@@ -23,9 +23,9 @@ public class PdpRequestBuilderImpl implements PdpRequestBuilder {
     public AppRessursData lagAppRessursData(AbacDataAttributter dataAttributter) {
 
         var builder = minimalbuilder()
-            .leggTilAktørIdSet(dataAttributter.getVerdier(StandardAbacAttributtType.AKTØR_ID))
-            .leggTilFødselsnumre(dataAttributter.getVerdier(StandardAbacAttributtType.FNR));
-        // TODO legg på saksnummer relevante steder (mange requests har saksnummer)
+            .leggTilIdenter(dataAttributter.getVerdier(StandardAbacAttributtType.AKTØR_ID))
+            .leggTilIdenter(dataAttributter.getVerdier(StandardAbacAttributtType.FNR));
+        // TODO legg på saksnummer relevante steder (mange requests har saksnummer). Send saksnummer hvis finnes, ellers ident
         // Ta med denne dataAttributter.getVerdier(StandardAbacAttributtType.SAKSNUMMER).stream().findFirst().map(String::valueOf).ifPresent(builder::medSaksnummer);
         return builder.build();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <kontrakt.java.version>21</kontrakt.java.version>
 
-		<felles.version>7.4.15</felles.version>
+		<felles.version>7.5.1</felles.version>
 		<prosesstask.version>5.1.5</prosesstask.version>
 		<kontrakter.version>9.2.7</kontrakter.version>
         <tidsserie.version>2.7.3</tidsserie.version>


### PR DESCRIPTION
Har beholdt struktur. Blir en egen jobb å sette en del saksnummer til NotNull i requests.
Mange requests har Ident + Saksnummer + uuid. Her må saksnummer gjøres NotNull og brukes der finnes.
En del requests har person i en variant som er aktørid eller fnr. Der det ikke finnes saksnummer brukes denne.