### PR TITLE
chore: Juster cpu og minne etter anbefaling / behov

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -3,12 +3,11 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "cpu": "2",
-    "mem": "2048Mi"
+    "mem": "800Mi"
   },
   "requests": {
-    "cpu": "200m",
-    "mem": "1024Mi"
+    "cpu": "50m",
+    "mem": "640Mi"
   },
   "ingresses": [
     "https://fpabakus.dev-fss-pub.nais.io"

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -38,7 +38,6 @@ spec:
         thresholdPercentage: 80
   resources:
     limits:
-      cpu: "{{limits.cpu}}"
       memory: "{{limits.mem}}"
     requests:
       cpu: "{{requests.cpu}}"

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -36,6 +36,7 @@ spec:
     scalingStrategy:
       cpu:
         thresholdPercentage: 80
+      scaleUpStabilizationWindowSeconds: 60
   resources:
     limits:
       memory: "{{limits.mem}}"

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -3,12 +3,11 @@
   "minReplicas": "2",
   "maxReplicas": "6",
   "limits": {
-    "cpu": "2",
-    "mem": "2048Mi"
+    "mem": "1000Mi"
   },
   "requests": {
-    "cpu": "500m",
-    "mem": "1024Mi"
+    "cpu": "100m",
+    "mem": "800Mi"
   },
   "ingresses": [
     "https://fpabakus.prod-fss-pub.nais.io"


### PR DESCRIPTION
Fjerner cpu-limit, og justerer cpu- og minneforespørsler til anbefalte verdier.

- Fjerner `limits.cpu` fra naiserator.yaml og JSON-filer
- Dev: cpu request=50m, mem request=640Mi, mem limit=800Mi
- Prod: cpu request=100m, mem request=800Mi, mem limit=1000Mi