### PR TITLE
TFP-7042 felles jetty server builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
         <abakus-kontrakt.version>2.4.1</abakus-kontrakt.version>
 
-		<felles.version>7.8.4</felles.version>
+		<felles.version>7.8.5</felles.version>
 		<prosesstask.version>5.2.7</prosesstask.version>
 		<kontrakter.version>9.4.37</kontrakter.version>
         <tidsserie.version>2.7.4</tidsserie.version>

--- a/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
+++ b/src/main/java/no/nav/foreldrepenger/abakus/jetty/JettyServer.java
@@ -2,20 +2,10 @@ package no.nav.foreldrepenger.abakus.jetty;
 
 import java.util.Locale;
 
-import org.eclipse.jetty.ee11.cdi.CdiDecoratingListener;
-import org.eclipse.jetty.ee11.cdi.CdiServletContainerInitializer;
-import org.eclipse.jetty.ee11.servlet.DefaultServlet;
-import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee11.servlet.ServletHolder;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.Constraint;
-import org.eclipse.jetty.server.Server;
 import org.flywaydb.core.api.FlywayException;
 import org.flywaydb.core.api.callback.BaseCallback;
 import org.flywaydb.core.api.callback.Context;
 import org.flywaydb.core.api.callback.Event;
-import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -30,12 +20,13 @@ import no.nav.vedtak.felles.jpa.NamingStandard;
 import no.nav.vedtak.felles.jpa.flyway.FlywayUtil;
 import no.nav.vedtak.felles.jpa.jdbc.DataSourceHolder;
 import no.nav.vedtak.log.metrics.MetricsUtil;
+import no.nav.vedtak.server.jetty.DataSourceShutdownListener;
+import no.nav.vedtak.server.jetty.JettyServerBuilder;
 
 public class JettyServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(JettyServer.class);
     private static final Environment ENV = Environment.current();
-    protected static final String APPLICATION = "jakarta.ws.rs.Application";
 
     private static final String CONTEXT_PATH = ENV.getProperty("context.path", "/fpabakus");
 
@@ -55,6 +46,7 @@ public class JettyServer {
     }
 
     void bootStrap() throws Exception {
+        MetricsUtil.init();
         konfigurerLogging();
         migrerDatabaser();
         konfigurerDataSource();
@@ -68,52 +60,23 @@ public class JettyServer {
     private static void konfigurerLogging() {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
-        MetricsUtil.scrape(); // TODO: bruke kommende init-metode
     }
 
     private void start() throws Exception{
-        var server = new Server(getServerPort());
         LOG.info("Starter server");
-        var context = new ServletContextHandler(CONTEXT_PATH, ServletContextHandler.NO_SESSIONS);
-
-        // Sikkerhet
-        context.setSecurityHandler(simpleConstraints());
-
-        // Servlets
-        registerDefaultServlet(context);
-        registerServlet(context, 0, InternalApiConfig.API_URI, InternalApiConfig.class);
-        registerServlet(context, 1, ApiConfig.API_URI, ApiConfig.class);
-        registerServlet(context, 2, ForvaltningApiConfig.API_URI, ForvaltningApiConfig.class);
-        registerServlet(context, 3, EksternApiConfig.API_URI, EksternApiConfig.class);
-
-        // Starter tjenester
-        context.addEventListener(new ServiceStarterListener());
-
-        // Enable Weld + CDI
-        context.setInitParameter(CdiServletContainerInitializer.CDI_INTEGRATION_ATTRIBUTE, CdiDecoratingListener.MODE);
-        context.addServletContainerInitializer(new CdiServletContainerInitializer());
-        context.addServletContainerInitializer(new org.jboss.weld.environment.servlet.EnhancedListener());
-
-        server.setHandler(context);
-        server.setStopAtShutdown(true);
-        server.setStopTimeout(10000);
+        var server = JettyServerBuilder.builder()
+            .port(getServerPort())
+            .contextPath(CONTEXT_PATH)
+            .addEventListener(new ServiceStarterListener())
+            .addEventListener(new DataSourceShutdownListener(DataSourceHolder::close))
+            .registerRestApp(InternalApiConfig.API_URI, InternalApiConfig.class)
+            .registerRestApp(ApiConfig.API_URI, ApiConfig.class)
+            .registerRestApp(ForvaltningApiConfig.API_URI, ForvaltningApiConfig.class)
+            .registerRestApp(EksternApiConfig.API_URI, EksternApiConfig.class)
+            .build();
         server.start();
-
         LOG.info("Server startet på port: {}", getServerPort());
         server.join();
-    }
-
-    private static void registerDefaultServlet(ServletContextHandler context) {
-        var defaultServlet = new ServletHolder(new DefaultServlet());
-        context.addServlet(defaultServlet, "/*");
-    }
-
-    private static void registerServlet(ServletContextHandler context, int prioritet, String path, Class<?> appClass) {
-        var servlet = new ServletHolder(new ServletContainer());
-        servlet.setName(appClass.getName());
-        servlet.setInitOrder(prioritet);
-        servlet.setInitParameter(APPLICATION, appClass.getName());
-        context.addServlet(servlet, path + "/*");
     }
 
     protected void konfigurerDataSource() {
@@ -146,28 +109,6 @@ public class JettyServer {
             }
             flyway.load().migrate();
         }
-    }
-
-    private static ConstraintSecurityHandler simpleConstraints() {
-        var handler = new ConstraintSecurityHandler();
-        // Slipp gjennom kall fra plattform til JaxRs. Foreløpig kun behov for GET
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, InternalApiConfig.API_URI + "/*"));
-        // Slipp gjennom til autentisering i JaxRs / auth-filter
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ApiConfig.API_URI + "/*"));
-        // Slipp gjennom til autentisering i JaxRs / auth-filter
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ForvaltningApiConfig.API_URI + "/*"));
-        // Slipp gjennom til autentisering i JaxRs / auth-filter
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, EksternApiConfig.API_URI + "/*"));
-        // Alt annet av paths og metoder forbudt - 403
-        handler.addConstraintMapping(pathConstraint(Constraint.FORBIDDEN, "/*"));
-        return handler;
-    }
-
-    private static ConstraintMapping pathConstraint(Constraint constraint, String path) {
-        var mapping = new ConstraintMapping();
-        mapping.setConstraint(constraint);
-        mapping.setPathSpec(path);
-        return mapping;
     }
 
     private Integer getServerPort() {


### PR DESCRIPTION
Adopterer felles JettyServerBuilder fra fp-felles (felles/server jetty-pakke) og oppgraderer felles til 7.8.5.

- Erstatter manuell Jetty/Connector/Context/sikkerhets-oppsett med JettyServerBuilder
- MetricsUtil.scrape() -> MetricsUtil.init() tidlig i boot (før logging/datasource), der relevant
- Legger til DataSourceShutdownListener der datasource/Flyway brukes

TFP-7042